### PR TITLE
fix(editorial): synchronize workspace drafts with blog posts

### DIFF
--- a/blog/migrations/0035_alter_post_title_non_unique.py
+++ b/blog/migrations/0035_alter_post_title_non_unique.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('blog', '0034_category_display_order'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='post',
+            name='title',
+            field=models.CharField(max_length=200),
+        ),
+    ]

--- a/blog/models.py
+++ b/blog/models.py
@@ -103,7 +103,8 @@ class Post(models.Model):
     content, author, and publication status. It also handles the featured image
     using Cloudinary for image storage.
     """
-    title = models.CharField(max_length=200, unique=True)
+    # Titles are display text and may repeat. Public URLs use ``slug`` (unique).
+    title = models.CharField(max_length=200)
     slug = models.SlugField(max_length=200, unique=True)
     author = models.ForeignKey(
         User, on_delete=models.CASCADE, related_name="blog_posts"
@@ -207,18 +208,40 @@ class Post(models.Model):
                         from django.utils.text import slugify
                         base_slug = slugify(self.title, allow_unicode=True) or f"post-{timezone.now().strftime('%Y%m%d%H%M%S')}"
                     
-                    self.slug = base_slug
+                    self.slug = self._allocate_unique_slug(base_slug)
                 except Exception:
                     # If slug generation fails, use timestamp-based fallback
                     if not self.slug:
-                        self.slug = f"post-{timezone.now().strftime('%Y%m%d%H%M%S')}"
+                        self.slug = self._allocate_unique_slug(
+                            f"post-{timezone.now().strftime('%Y%m%d%H%M%S')}"
+                        )
         except Exception:
             # If anything fails, ensure we have a slug before saving
             if not self.slug:
-                self.slug = f"post-{timezone.now().strftime('%Y%m%d%H%M%S')}"
+                self.slug = self._allocate_unique_slug(
+                    f"post-{timezone.now().strftime('%Y%m%d%H%M%S')}"
+                )
         
         # Save the object - let Django handle any errors naturally
         super().save(*args, **kwargs)
+
+    def _allocate_unique_slug(self, base_slug: str) -> str:
+        """Keep slug unique when titles are allowed to repeat."""
+        candidate = (base_slug or '').strip('-')[:200] or (
+            f"post-{timezone.now().strftime('%Y%m%d%H%M%S')}"
+        )
+        qs = Post.objects.all()
+        if self.pk:
+            qs = qs.exclude(pk=self.pk)
+        if not qs.filter(slug=candidate).exists():
+            return candidate
+        for index in range(2, 1000):
+            suffix = f'-{index}'
+            trimmed = candidate[: max(1, 200 - len(suffix))].rstrip('-')
+            next_slug = f'{trimmed}{suffix}'
+            if not qs.filter(slug=next_slug).exists():
+                return next_slug
+        return f"{candidate[:180]}-{timezone.now().strftime('%Y%m%d%H%M%S')}"
 
     def favorite_count(self):
         """Returns the number of users who have favorited this post."""

--- a/content_ai/editorial/image/__init__.py
+++ b/content_ai/editorial/image/__init__.py
@@ -3,6 +3,8 @@
 from content_ai.editorial.image.attach import (
     FeaturedImageAttachError,
     attach_featured_image_to_post,
+    extract_cloudinary_public_id,
+    resolve_featured_image_public_id,
     upload_featured_image_asset,
 )
 from content_ai.editorial.image.planner import ImagePlan, plan_featured_image
@@ -25,8 +27,10 @@ __all__ = [
     'ImagePlan',
     'attach_featured_image_to_post',
     'build_featured_image_brief',
+    'extract_cloudinary_public_id',
     'list_image_styles_for_ui',
     'plan_featured_image',
+    'resolve_featured_image_public_id',
     'resolve_image_style',
     'upload_featured_image_asset',
 ]

--- a/content_ai/editorial/image/attach.py
+++ b/content_ai/editorial/image/attach.py
@@ -6,6 +6,7 @@ import base64
 import logging
 import re
 from typing import Any
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
@@ -18,6 +19,49 @@ _DATA_URL_RE = re.compile(
     r'^data:(image/[a-zA-Z0-9.+-]+);base64,(.+)$',
     re.DOTALL,
 )
+# Cloudinary delivery URL → public_id (with optional folder path).
+_CLOUDINARY_UPLOAD_RE = re.compile(
+    r'/upload/(?:[^/]+/)*?(?:v\d+/)?(.+?)(?:\.[a-zA-Z0-9]+)?$'
+)
+
+
+def extract_cloudinary_public_id(value: str) -> str:
+    """
+    Return a Cloudinary public_id from a public_id string or delivery URL.
+
+    Examples:
+    - ``peyvand/editorial/featured/abc`` → same
+    - ``https://res.cloudinary.com/.../upload/v123/peyvand/editorial/featured/abc.png``
+      → ``peyvand/editorial/featured/abc``
+    """
+    raw = (value or '').strip()
+    if not raw:
+        return ''
+    if raw.startswith('data:'):
+        return ''
+    if 'res.cloudinary.com' in raw or '/image/upload/' in raw or '/upload/' in raw:
+        path = urlparse(raw).path
+        match = _CLOUDINARY_UPLOAD_RE.search(path)
+        if match:
+            return match.group(1).lstrip('/')
+        return ''
+    # Already a public_id (possibly with folders).
+    return raw.lstrip('/')
+
+
+def resolve_featured_image_public_id(featured: dict[str, Any] | None) -> str:
+    """Pick the best Cloudinary public_id from featured-image session state."""
+    state = dict(featured or {})
+    for key in (
+        'cloudinary_public_id',
+        'preview_cloudinary_public_id',
+        'attached_url',
+        'image_url',
+    ):
+        found = extract_cloudinary_public_id(str(state.get(key) or ''))
+        if found and found != 'placeholder':
+            return found
+    return ''
 
 
 def upload_featured_image_asset(
@@ -35,6 +79,23 @@ def upload_featured_image_asset(
     if not source:
         raise FeaturedImageAttachError('No image URL to upload.')
 
+    # Reuse an existing Cloudinary asset without re-uploading when possible.
+    existing = extract_cloudinary_public_id(source)
+    if existing and source.startswith('http') and 'res.cloudinary.com' in source:
+        logger.info(
+            'Cloudinary featured image reuse existing public_id=%s',
+            existing,
+        )
+        return {
+            'public_id': existing,
+            'secure_url': source,
+            'bytes': None,
+            'format': None,
+            'width': None,
+            'height': None,
+            'reused': True,
+        }
+
     try:
         import cloudinary.uploader
     except ImportError as exc:
@@ -48,13 +109,16 @@ def upload_featured_image_asset(
         'resource_type': 'image',
         'overwrite': True,
     }
+    # ``folder`` already namespaces the asset — public_id must be the leaf only,
+    # otherwise Cloudinary doubles the path (folder/folder/id).
     if session_id:
-        options['public_id'] = f'{folder}/{session_id[:32]}'
+        leaf = re.sub(r'[^a-zA-Z0-9_-]+', '-', str(session_id)[:32]).strip('-')
+        if leaf:
+            options['public_id'] = leaf
 
     file_arg: Any = source
     match = _DATA_URL_RE.match(source)
     if match:
-        # Cloudinary accepts raw bytes for data-URL uploads in tests/mocks.
         try:
             file_arg = base64.b64decode(match.group(2))
         except Exception as exc:  # noqa: BLE001
@@ -76,6 +140,11 @@ def upload_featured_image_asset(
         raise FeaturedImageAttachError(
             'Cloudinary upload returned no public_id.'
         )
+    logger.info(
+        'Cloudinary featured image uploaded public_id=%s url=%s',
+        public_id,
+        (secure_url or '')[:160],
+    )
     return {
         'public_id': public_id,
         'secure_url': secure_url,
@@ -83,6 +152,7 @@ def upload_featured_image_asset(
         'format': (result or {}).get('format'),
         'width': (result or {}).get('width'),
         'height': (result or {}).get('height'),
+        'reused': False,
     }
 
 
@@ -90,9 +160,34 @@ def attach_featured_image_to_post(post, *, public_id: str) -> Any:
     """Set ``Post.featured_image`` to a Cloudinary public_id and save."""
     if post is None:
         raise FeaturedImageAttachError('Post is required.')
-    pid = (public_id or '').strip()
-    if not pid:
+    pid = extract_cloudinary_public_id(public_id) or (public_id or '').strip()
+    if not pid or pid == 'placeholder':
         raise FeaturedImageAttachError('Cloudinary public_id is required.')
+
+    # Full save — CloudinaryField has historically not persisted reliably with
+    # update_fields=['featured_image'] alone.
     post.featured_image = pid
-    post.save(update_fields=['featured_image'])
+    post.save()
+    post.refresh_from_db(fields=['featured_image'])
+
+    stored = ''
+    raw = post.featured_image
+    if raw is not None:
+        stored = (
+            getattr(raw, 'public_id', None)
+            or extract_cloudinary_public_id(str(raw))
+            or str(raw)
+        )
+    stored = (stored or '').strip()
+    logger.info(
+        'attach_featured_image_to_post post_id=%s requested=%s stored=%s',
+        getattr(post, 'pk', None),
+        pid,
+        stored,
+    )
+    if not stored or stored == 'placeholder':
+        raise FeaturedImageAttachError(
+            f'Post.featured_image remained placeholder after save '
+            f'(requested public_id={pid!r}).'
+        )
     return post

--- a/content_ai/editorial/image/planner.py
+++ b/content_ai/editorial/image/planner.py
@@ -1,69 +1,334 @@
-"""Internal image planner — understand the article before prompting.
+"""Internal image planner v2 — primary visual subject before prompting.
 
 Planner output is INTERNAL ONLY and must not be shown to editors.
+
+Core question the planner must answer:
+"If this article were printed on the front page of a newspaper,
+what should the photograph show?"
+— not "what is this article generally related to?"
 """
 
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
 
+
 from content_ai.editorial.image.style import (
-    category_visual_hint,
-    content_type_visual,
     resolve_image_style,
 )
 
 
 @dataclass(frozen=True, slots=True)
 class ImagePlan:
-    """Structured visual plan derived from the article (internal)."""
+    """Structured visual plan (v2) derived from the article (internal)."""
 
-    main_subject: str
-    secondary_subject: str
-    environment: str
-    visual_focus: str
-    camera_angle: str
-    composition: str
-    mood: str
-    lighting: str
-    visual_complexity: str
-    image_style: str
-    things_to_avoid: str
-    content_type_cue: str
-    category_cue: str
+    primary_subject: str
+    primary_visual_subject: str
+    location: str
+    secondary_elements: tuple[str, ...] = ()
+    visual_style: str = 'Editorial photography'
+    mood: str = 'Professional, trustworthy, institutional, calm, clean'
+    avoid: tuple[str, ...] = ()
+
+    # Legacy aliases kept for older session metadata / tests.
+    @property
+    def main_subject(self) -> str:
+        return self.primary_visual_subject
+
+    @property
+    def secondary_subject(self) -> str:
+        return ', '.join(self.secondary_elements) if self.secondary_elements else ''
+
+    @property
+    def environment(self) -> str:
+        return self.location
+
+    @property
+    def things_to_avoid(self) -> str:
+        return ', '.join(self.avoid)
 
     def to_dict(self) -> dict:
-        return asdict(self)
+        payload = asdict(self)
+        payload['secondary_elements'] = list(self.secondary_elements)
+        payload['avoid'] = list(self.avoid)
+        # Compatibility keys used by older UI/tests.
+        payload['main_subject'] = self.primary_visual_subject
+        payload['secondary_subject'] = self.secondary_subject
+        payload['environment'] = self.location
+        payload['things_to_avoid'] = self.things_to_avoid
+        return payload
 
     def to_prompt_block(self) -> str:
+        secondary = (
+            ', '.join(self.secondary_elements)
+            if self.secondary_elements
+            else 'none'
+        )
+        avoid = ', '.join(self.avoid) if self.avoid else 'none'
         lines = [
-            f'Main visual subject: {self.main_subject}',
+            f'Primary subject (what the article is about): {self.primary_subject}',
             (
-                f'Secondary subject (optional): {self.secondary_subject}'
-                if self.secondary_subject
-                else 'Secondary subject: none'
+                'Primary visual subject (front-page photograph): '
+                f'{self.primary_visual_subject}'
             ),
-            f'Environment: {self.environment}',
-            f'Visual focus: {self.visual_focus}',
-            f'Camera angle: {self.camera_angle}',
-            f'Composition: {self.composition}',
+            f'Location: {self.location}',
+            f'Secondary elements (optional, max two): {secondary}',
+            f'Visual style: {self.visual_style}',
             f'Mood: {self.mood}',
-            f'Lighting: {self.lighting}',
-            f'Visual complexity: {self.visual_complexity}',
-            f'Image style: {self.image_style}',
-            f'Things to avoid: {self.things_to_avoid}',
-            f'Content-type cue: {self.content_type_cue}',
-            f'Category cue: {self.category_cue}',
+            f'Avoid: {avoid}',
+            'Visual complexity: exactly one primary subject; max two supporting '
+            'elements; no collage, no infographic, no text in the image.',
         ]
         return '\n'.join(lines)
 
 
-_AVOID = (
-    'crowded scenes, large groups, fantasy, sci-fi, surrealism, abstract '
-    'symbolism, overly artistic compositions, heavy cinematic effects, '
-    'extreme HDR, heavy contrast, lens flares, fire, explosions, action '
-    'scenes, visual clutter, unnecessary objects, readable text, logos, '
-    'watermarks, captions, screens, UI, typography'
+# Baseline avoid list — always applied unless the article is specifically
+# about those subjects.
+_BASE_AVOID: tuple[str, ...] = (
+    'generic smiling people',
+    'shopping',
+    'children',
+    'elderly people',
+    'medical scenes unrelated to the topic',
+    'food',
+    'family moments',
+    'random city streets',
+    'tourism',
+    'lifestyle photography',
+    'coffee shops',
+    'grocery delivery',
+    'crowded scenes',
+    'large groups',
+    'fantasy',
+    'sci-fi',
+    'surrealism',
+    'readable text',
+    'logos',
+    'watermarks',
+    'typography',
+    'collage',
+    'infographic',
+)
+
+
+@dataclass(frozen=True, slots=True)
+class _TopicRule:
+    """Keyword → institutional visual mapping."""
+
+    id: str
+    keywords: tuple[str, ...]
+    primary_subject: str
+    primary_visual_subject: str
+    location: str
+    secondary_elements: tuple[str, ...]
+    visual_style_photo: str
+    mood: str
+    extra_avoid: tuple[str, ...] = ()
+
+
+# Ordered by specificity — first match wins.
+_TOPIC_RULES: tuple[_TopicRule, ...] = (
+    _TopicRule(
+        id='constitution_parliament',
+        keywords=(
+            'constitution', 'grundlag', 'قانون اساسی', 'قوانین اساسی',
+            'riksdag', 'riksdagen', 'parliament', 'پارلمان', 'مجلس',
+            'ریکسداگ', 'ریکسداگ‌اوردنینگ', 'ریکسداگاوردنینگ',
+            'regeringsformen', 'successionsordningen',
+            'tryckfrihetsförordningen', 'yttrandefrihetsgrundlagen',
+        ),
+        primary_subject='Swedish Constitution and Parliament',
+        primary_visual_subject=(
+            'The Swedish Parliament building (Riksdagen) exterior or '
+            'parliament chamber interior'
+        ),
+        location='Riksdagen, Stockholm, Sweden',
+        secondary_elements=('official legal documents', 'subtle Swedish flag'),
+        visual_style_photo='Architectural / documentary editorial photography',
+        mood='Institutional, trustworthy, serious, calm, clean',
+        extra_avoid=(
+            'elderly receiving groceries',
+            'community volunteering',
+            'home interiors',
+            'shopping bags',
+        ),
+    ),
+    _TopicRule(
+        id='government_politics',
+        keywords=(
+            'government', 'regering', 'دولت', 'وزیر', 'minister',
+            'politik', 'politics', 'سیاست', 'cabinet', 'rosenbad',
+            'government offices', 'statsminister',
+        ),
+        primary_subject='Swedish government / politics',
+        primary_visual_subject=(
+            'Swedish Government Offices exterior or formal government building'
+        ),
+        location='Government Offices, Stockholm, Sweden',
+        secondary_elements=('official documents', 'microphones at a press podium'),
+        visual_style_photo='Editorial / architectural photography',
+        mood='Institutional, professional, trustworthy, calm',
+        extra_avoid=('lifestyle scenes', 'casual street portraits'),
+    ),
+    _TopicRule(
+        id='law_courts',
+        keywords=(
+            'court', 'domstol', 'دادگاه', 'supreme court', 'högsta domstolen',
+            'law books', 'legal', 'حقوقی', 'قاضی', 'judge', 'آیین‌نامه',
+        ),
+        primary_subject='Law and courts',
+        primary_visual_subject='Courtroom or official legal documents and law books',
+        location='Swedish court building or formal legal office',
+        secondary_elements=('law books', 'official papers'),
+        visual_style_photo='Documentary editorial photography',
+        mood='Serious, institutional, trustworthy, clean',
+    ),
+    _TopicRule(
+        id='tax',
+        keywords=(
+            'tax', 'skatt', 'مالیات', 'skatteverket', 'skatte',
+        ),
+        primary_subject='Tax / Skatteverket',
+        primary_visual_subject=(
+            'Official tax authority office exterior or desk with unmarked '
+            'official documents and calculator'
+        ),
+        location='Swedish tax authority / government office',
+        secondary_elements=('official documents', 'calculator'),
+        visual_style_photo='Editorial photography',
+        mood='Professional, trustworthy, clean, calm',
+        extra_avoid=('coffee lifestyle', 'home kitchen', 'shopping'),
+    ),
+    _TopicRule(
+        id='immigration',
+        keywords=(
+            'migration', 'مهاجرت', 'migrationsverket', 'asyl', 'uppehåll',
+            'immigration', 'passport', 'گذرنامه', 'پناه', 'border',
+        ),
+        primary_subject='Immigration / migration',
+        primary_visual_subject=(
+            'Migration office waiting area or passport and official documents '
+            'on a counter'
+        ),
+        location='Migrationsverket / Swedish migration office',
+        secondary_elements=('passport', 'official documents'),
+        visual_style_photo='Documentary editorial photography',
+        mood='Respectful, institutional, calm, clean',
+        extra_avoid=('tourist photos', 'family picnic', 'airport shopping'),
+    ),
+    _TopicRule(
+        id='police',
+        keywords=('police', 'polis', 'پلیس', 'brott', 'جرم'),
+        primary_subject='Police',
+        primary_visual_subject=(
+            'Swedish police officers or a police vehicle outside a station'
+        ),
+        location='Swedish police station exterior or quiet street',
+        secondary_elements=('police vehicle',),
+        visual_style_photo='Documentary editorial photography',
+        mood='Calm, professional, trustworthy',
+        extra_avoid=('action chase', 'violence', 'weapons close-up'),
+    ),
+    _TopicRule(
+        id='healthcare',
+        keywords=(
+            'health', 'vård', 'سلامت', 'sjuk', 'healthcare', 'clinic',
+            'hospital', 'بیمارستان', 'پزشک', 'doctor', 'nurse',
+        ),
+        primary_subject='Healthcare',
+        primary_visual_subject='Hospital corridor or doctor with medical equipment',
+        location='Swedish hospital / clinic interior',
+        secondary_elements=('medical equipment',),
+        visual_style_photo='Documentary editorial photography',
+        mood='Calm, professional, trustworthy, clean',
+        # Healthcare IS the topic — do not avoid medical scenes.
+        extra_avoid=('shopping', 'tourism'),
+    ),
+    _TopicRule(
+        id='education',
+        keywords=(
+            'education', 'utbildning', 'آموزش', 'school', 'skolan',
+            'university', 'دانشگاه', 'student', 'دانشجو', 'teacher', 'معلم',
+        ),
+        primary_subject='Education',
+        primary_visual_subject='University campus or classroom with students and teacher',
+        location='Swedish school or university',
+        secondary_elements=('books', 'desks'),
+        visual_style_photo='Documentary editorial photography',
+        mood='Bright, professional, calm, clean',
+    ),
+    _TopicRule(
+        id='economy',
+        keywords=(
+            'economy', 'ekonomi', 'اقتصاد', 'finance', 'currency', 'krona',
+            'industry', 'شرکت', 'company', 'börs', 'bank', 'بانک',
+        ),
+        primary_subject='Economy / finance',
+        primary_visual_subject=(
+            'Modern business district, finance office, or industrial facility'
+        ),
+        location='Swedish business district or company office',
+        secondary_elements=('office documents', 'city skyline through a window'),
+        visual_style_photo='Editorial photography',
+        mood='Modern, professional, trustworthy, clean',
+        extra_avoid=('graphs with readable numbers', 'stock ticker text'),
+    ),
+    _TopicRule(
+        id='housing',
+        keywords=(
+            'housing', 'bostad', 'مسکن', 'apartment', 'hyra', 'اجاره',
+            'مستاجر', 'landlord',
+        ),
+        primary_subject='Housing',
+        primary_visual_subject='Swedish residential building exterior or apartment entrance',
+        location='Swedish residential neighbourhood',
+        secondary_elements=('house keys',),
+        visual_style_photo='Architectural / editorial photography',
+        mood='Calm, clean, trustworthy',
+        extra_avoid=('furniture showroom lifestyle', 'family dinner'),
+    ),
+    _TopicRule(
+        id='technology',
+        keywords=(
+            'technology', 'teknik', 'فناوری', 'digital', 'ai', 'هوش مصنوعی',
+            'software', 'server', 'data', 'developer',
+        ),
+        primary_subject='Technology / digital infrastructure',
+        primary_visual_subject=(
+            'Server room, data centre aisle, or clean modern tech workspace'
+        ),
+        location='Modern tech office or data centre',
+        secondary_elements=('servers', 'laptop without readable screen text'),
+        visual_style_photo='Editorial photography',
+        mood='Modern, clean, professional',
+        extra_avoid=('readable UI', 'screens with text'),
+    ),
+    _TopicRule(
+        id='culture',
+        keywords=(
+            'culture', 'kultur', 'فرهنگ', 'museum', 'موزه', 'concert',
+            'کنسرت', 'artist', 'هنرمند', 'performance', 'theatre', 'تئاتر',
+        ),
+        primary_subject='Culture / arts',
+        primary_visual_subject='Museum gallery, concert hall, or performance stage',
+        location='Swedish cultural venue',
+        secondary_elements=('stage lighting',),
+        visual_style_photo='Editorial photography',
+        mood='Creative yet professional, calm, clean',
+    ),
+    _TopicRule(
+        id='transport',
+        keywords=(
+            'transport', 'trafik', 'حمل', 'train', 'bus', 'bil', 'körkort',
+            'قطار', 'اتوبوس',
+        ),
+        primary_subject='Transport',
+        primary_visual_subject='Swedish train station, bus, or clear road scene',
+        location='Swedish public transport setting',
+        secondary_elements=('platform',),
+        visual_style_photo='Documentary editorial photography',
+        mood='Calm, clean, modern',
+    ),
 )
 
 
@@ -74,17 +339,40 @@ def _clip(text: str, limit: int) -> str:
     return cleaned[: max(0, limit - 1)].rstrip() + '…'
 
 
-def _people_needed(blob: str, content_type: str) -> bool:
-    lowered = blob.lower()
-    type_key = (content_type or '').lower()
-    if type_key in {'interview', 'community_story', 'community', 'guide', 'howto'}:
-        return True
-    people_markers = (
-        'interview', 'مصاحبه', 'teacher', 'student', 'doctor', 'nurse',
-        'police', 'polis', 'پلیس', 'family', 'خانواده', 'migrant', 'مهاجر',
-        'entrepreneur', 'meeting', 'community', 'انجمن', 'کمک',
-    )
-    return any(marker in lowered for marker in people_markers)
+def _normalize_blob(*parts: str) -> str:
+    return ' '.join(p for p in parts if p).lower()
+
+
+def _match_topic(blob: str) -> _TopicRule | None:
+    for rule in _TOPIC_RULES:
+        if any(keyword.lower() in blob for keyword in rule.keywords):
+            return rule
+    return None
+
+
+def _build_avoid(
+    rule: _TopicRule | None,
+    *,
+    topic_allows_people: bool,
+    topic_is_healthcare: bool,
+) -> tuple[str, ...]:
+    avoid: list[str] = list(_BASE_AVOID)
+    if rule:
+        avoid.extend(rule.extra_avoid)
+    if topic_is_healthcare:
+        avoid = [a for a in avoid if 'medical' not in a.lower()]
+    if topic_allows_people:
+        # Keep generic lifestyle people banned; institutional people OK.
+        pass
+    # Deduplicate while preserving order.
+    seen: set[str] = set()
+    out: list[str] = []
+    for item in avoid:
+        key = item.lower()
+        if key not in seen:
+            seen.add(key)
+            out.append(item)
+    return tuple(out)
 
 
 def plan_featured_image(
@@ -99,7 +387,7 @@ def plan_featured_image(
     image_style: str | None = None,
 ) -> ImagePlan:
     """
-    Derive an internal visual plan from article understanding.
+    Derive an internal v2 visual plan from article understanding.
 
     Requires article substance (not URL / title alone).
     """
@@ -117,99 +405,81 @@ def plan_featured_image(
     content_type = (content_type or 'news').strip() or 'news'
     category = (category or '').strip()
     style = resolve_image_style(image_style)
-    blob = f'{headline}\n{lead}\n{body}\n{category}\n{" ".join(tags)}'
-    type_cue = content_type_visual(content_type)
-    cat_cue = category_visual_hint(
-        category=category,
-        tags=tags,
-        text_blob=blob,
+
+    # Prefer headline + lead for subject extraction; body is secondary signal.
+    blob = _normalize_blob(
+        headline,
+        lead,
+        body[:1200],
+        category,
+        ' '.join(tags),
+        content_type,
+        goal or '',
     )
+    rule = _match_topic(blob)
 
-    topic = _clip(headline or lead, 120) or 'the article topic'
-    needs_people = _people_needed(blob, content_type)
-
-    if 'tax' in cat_cue.lower() or 'desk' in cat_cue.lower():
-        main = 'A calm desk with tax papers, laptop, calculator and coffee'
-        environment = 'Quiet Scandinavian home-office or desk'
-        secondary = 'Soft window light in the background'
-    elif 'police' in cat_cue.lower():
-        main = 'A Swedish-style police officer or police vehicle on a calm street'
-        environment = 'Quiet Swedish street or police-station exterior'
-        secondary = ''
-    elif 'classroom' in cat_cue.lower() or 'education' in cat_cue.lower():
-        main = 'Teacher and student with books in a simple classroom'
-        environment = 'Bright Swedish classroom'
-        secondary = 'Books on a desk'
-    elif 'clinic' in cat_cue.lower() or 'healthcare' in cat_cue.lower():
-        main = 'Doctor in a calm medical consultation'
-        environment = 'Clean Swedish clinic interior'
-        secondary = ''
-    elif 'office' in cat_cue.lower() or 'meeting' in cat_cue.lower():
-        main = 'Small-company meeting or entrepreneur at a clean desk'
-        environment = 'Modern Scandinavian office'
-        secondary = ''
-    elif 'technology' in cat_cue.lower() or 'laptop' in cat_cue.lower() and 'tax' not in cat_cue.lower():
-        main = 'Developer or clean laptop workspace'
-        environment = 'Modern office with natural light'
-        secondary = ''
-    elif 'apartment' in cat_cue.lower() or 'housing' in cat_cue.lower() or 'keys' in cat_cue.lower():
-        main = 'Residential building, apartment entrance, or house keys'
-        environment = 'Swedish residential exterior or hallway'
-        secondary = 'Moving boxes optional, uncluttered'
-    elif 'government' in cat_cue.lower() or 'migration' in cat_cue.lower():
-        main = 'Calm government waiting area with documents'
-        environment = 'Scandinavian public office interior'
-        secondary = 'One or two people waiting respectfully' if needs_people else ''
-    elif 'community' in cat_cue.lower() or 'conversation' in cat_cue.lower():
-        main = 'Friendly conversation / people helping each other'
-        environment = 'Everyday community setting in Sweden'
-        secondary = 'Small group, maximum two people in focus'
+    if rule is not None:
+        primary_subject = rule.primary_subject
+        primary_visual = rule.primary_visual_subject
+        location = rule.location
+        secondary = rule.secondary_elements[:2]
+        mood = rule.mood
+        photo_style = rule.visual_style_photo
+        topic_is_healthcare = rule.id == 'healthcare'
+        topic_allows_people = rule.id in {
+            'police',
+            'healthcare',
+            'education',
+            'immigration',
+        }
     else:
-        main = f'One clear real-world subject representing: {topic}'
-        environment = 'Authentic Swedish / Scandinavian everyday setting when relevant'
-        secondary = 'One supporting detail only if needed'
-
-    if content_type in {'interview'}:
-        main = 'Interview subject in a calm interview setting'
-        camera = 'Eye-level medium shot'
-        mood = 'Attentive, respectful, calm'
-    elif content_type in {'guide', 'howto', 'explainer', 'faq'}:
-        camera = 'Slightly elevated or eye-level, clear instructional framing'
-        mood = 'Bright, friendly, educational'
-    elif content_type in {'analysis', 'opinion', 'editorial'}:
-        camera = 'Clean wide or medium shot with strong negative space'
-        mood = 'Thoughtful, minimal, serious'
-    elif content_type in {'report', 'reportage'}:
-        camera = 'Documentary eye-level'
-        mood = 'Observational, grounded'
-    else:
-        camera = 'Natural eye-level editorial framing'
-        mood = 'Calm, professional, trustworthy'
-
-    style_label = (
-        'Highly realistic professional editorial photography, magazine quality'
-        if style == 'editorial_photo'
-        else (
-            'Clean modern editorial magazine illustration, minimal, flat or '
-            'softly rendered — not cartoon, not fantasy'
+        topic = _clip(headline or lead, 100) or 'the article topic'
+        primary_subject = topic
+        primary_visual = (
+            f'One clear institutional or real-world subject that would appear '
+            f'on a newspaper front page about: {topic}'
         )
+        location = 'Sweden — authentic setting matching the article subject'
+        secondary = ()
+        mood = 'Professional, trustworthy, institutional, calm, clean'
+        photo_style = 'Editorial photography'
+        topic_is_healthcare = False
+        topic_allows_people = content_type in {
+            'interview',
+            'community_story',
+            'community',
+        }
+
+    if style == 'editorial_illustration':
+        visual_style = (
+            'Clean modern editorial magazine illustration — minimal, '
+            'professional, not cartoon, not fantasy'
+        )
+    else:
+        visual_style = photo_style
+
+    # Content-type mood nudges without changing the primary visual subject.
+    if content_type in {'analysis', 'opinion', 'editorial'}:
+        mood = f'{mood}; thoughtful, minimal'
+    elif content_type in {'guide', 'howto', 'explainer', 'faq'}:
+        mood = f'{mood}; clear and educational'
+    elif content_type == 'interview' and rule is None:
+        primary_visual = 'Interview subject in a calm professional setting'
+        secondary = ('microphone',)
+        topic_allows_people = True
+
+    avoid = _build_avoid(
+        rule,
+        topic_allows_people=topic_allows_people,
+        topic_is_healthcare=topic_is_healthcare,
     )
 
     return ImagePlan(
-        main_subject=main,
-        secondary_subject=secondary,
-        environment=environment,
-        visual_focus='Large clear primary subject; readable as a thumbnail',
-        camera_angle=camera,
-        composition=(
-            'Simple balanced 16:9 layout, one visual idea, clean background, '
-            'natural perspective'
-        ),
+        primary_subject=primary_subject,
+        primary_visual_subject=primary_visual,
+        location=location,
+        secondary_elements=secondary,
+        visual_style=visual_style,
         mood=mood,
-        lighting='Natural daylight, soft and even — no dramatic cinematic lighting',
-        visual_complexity='Low — prefer simplicity over detail',
-        image_style=style_label,
-        things_to_avoid=_AVOID,
-        content_type_cue=type_cue,
-        category_cue=cat_cue,
+        avoid=avoid,
     )

--- a/content_ai/editorial/image/prompt.py
+++ b/content_ai/editorial/image/prompt.py
@@ -1,4 +1,8 @@
-"""Build featured-image prompts from article understanding + image plan."""
+"""Build featured-image prompts from the structured Image Plan (v2).
+
+The OpenAI prompt is built from planner JSON fields — not from long
+article dumps that drift into generic lifestyle scenes.
+"""
 
 from __future__ import annotations
 
@@ -7,11 +11,8 @@ from typing import Any
 
 from content_ai.editorial.image.planner import ImagePlan, plan_featured_image
 from content_ai.editorial.image.style import (
-    IMAGE_STYLE_GUIDANCE,
     IMAGE_STYLE_LABELS,
     PEYVAND_STYLE_BLOCK,
-    PEOPLE_RULES,
-    SWEDEN_RULES,
     resolve_image_style,
 )
 
@@ -51,9 +52,8 @@ def build_featured_image_brief(
     plan: ImagePlan | None = None,
 ) -> FeaturedImageBrief:
     """
-    Build an English image-generation prompt from Persian article fields.
+    Plan first, then build an English image prompt from the structured plan.
 
-    Always plans the image first (unless an ImagePlan is supplied).
     Never uses a source URL alone — requires editorial article content.
     Never uses title alone.
     """
@@ -73,10 +73,8 @@ def build_featured_image_brief(
     content_type = (content_type or 'news').strip() or 'news'
     goal = (goal or '').strip()
     category = (category or '').strip()
-    publisher = (publisher or '').strip()
     style = resolve_image_style(image_style)
     style_label = IMAGE_STYLE_LABELS.get(style, style)
-    style_guidance = IMAGE_STYLE_GUIDANCE.get(style, '')
 
     if plan is None:
         plan = plan_featured_image(
@@ -90,43 +88,47 @@ def build_featured_image_brief(
             image_style=style,
         )
 
-    subject_lines = [
-        f'Article headline (Persian): {_clip(headline, 220)}' if headline else '',
-        f'Lead (Persian): {_clip(lead, 400)}' if lead else '',
-        f'Article excerpt (Persian): {_clip(body, 900)}' if body else '',
-        f'Content type: {content_type}.',
-        f'Editorial goal: {goal}.' if goal else '',
-        f'Category: {category}.' if category else '',
-        f'Tags: {", ".join(tags)}.' if tags else '',
-        f'Publisher context: {publisher}.' if publisher else '',
-        f'Selected image style: {style_label}.',
-        style_guidance,
-    ]
-    subject_block = '\n'.join(line for line in subject_lines if line)
+    secondary = (
+        ', '.join(plan.secondary_elements)
+        if plan.secondary_elements
+        else 'none'
+    )
+    avoid = ', '.join(plan.avoid) if plan.avoid else 'generic lifestyle scenes'
 
+    # Prompt is driven by the structured plan (front-page photograph rule).
     prompt = (
-        'Create a professional featured image for a Persian news / community '
-        'website article.\n'
-        'Communicate the article\'s main idea clearly and professionally. '
-        'Do NOT create artistic, fantasy, or cinematic spectacle imagery.\n\n'
+        'Create one professional 16:9 featured image for a Persian news / '
+        'community website.\n'
+        'Answer this brief as a newspaper front-page photograph would: show '
+        'the article\'s primary institutional or real-world subject — not a '
+        'generic Swedish lifestyle scene.\n\n'
         f'{PEYVAND_STYLE_BLOCK}\n\n'
-        f'{PEOPLE_RULES}\n\n'
-        f'{SWEDEN_RULES}\n\n'
-        f'{style_guidance}\n\n'
-        'Internal visual plan (follow closely; do not render as text):\n'
+        'STRUCTURED IMAGE PLAN (follow exactly; do not render as text):\n'
         f'{plan.to_prompt_block()}\n\n'
-        'Article context (use for meaning only; do not render any of this as '
-        'text in the image):\n'
-        f'{subject_block}\n\n'
-        'Final instruction: produce one clean 16:9 editorial image that a '
-        'reader understands within two seconds from a thumbnail.'
+        'Render instructions:\n'
+        f'- Show primarily: {plan.primary_visual_subject}\n'
+        f'- Location: {plan.location}\n'
+        f'- Supporting elements only if needed (max two): {secondary}\n'
+        f'- Style: {plan.visual_style}\n'
+        f'- Mood: {plan.mood}\n'
+        f'- Hard avoid: {avoid}\n'
+        '- Exactly one primary subject. No collage. No infographic. '
+        'No readable text, logos, or watermarks.\n\n'
+        'Article topic anchor (meaning only; never render as text):\n'
+        f'- Headline: {_clip(headline, 160)}\n'
+        f'- Lead: {_clip(lead, 180)}\n'
+        f'- Category: {category or content_type or "news"}\n'
+        f'- Editor style: {style_label}\n\n'
+        'Final instruction: produce one clean editorial image that a reader '
+        'understands within two seconds from a thumbnail, matching the '
+        'primary visual subject above.'
     )
 
     explanation = (
-        f'{style_label} concept focused on “{plan.main_subject}” in '
-        f'{plan.environment}, matching '
-        f'{category or content_type or "the article topic"}. '
-        f'Peyvand minimal editorial identity — clear as a hero and thumbnail.'
+        f'{style_label} front-page concept: “{plan.primary_visual_subject}” '
+        f'for “{plan.primary_subject}”'
+        f'{f" at {plan.location}" if plan.location else ""}. '
+        f'Peyvand minimal editorial identity — institutional relevance over lifestyle.'
     )
 
     return FeaturedImageBrief(

--- a/content_ai/editorial/image/style.py
+++ b/content_ai/editorial/image/style.py
@@ -74,10 +74,10 @@ CONTENT_TYPE_VISUALS: dict[str, str] = {
     'reportage': 'Documentary-style realistic imagery.',
     'feature': 'Editorial photography with a clear human or place focus.',
     'community_story': (
-        'Friendly conversation / helping each other — authentic interaction.'
+        'Concrete community institution or place — not generic lifestyle.'
     ),
     'community': (
-        'Friendly conversation / helping each other — authentic interaction.'
+        'Concrete community institution or place — not generic lifestyle.'
     ),
     'press_release': 'Professional institutional or workplace setting.',
     'announcement': 'Clear institutional or community setting without clutter.',
@@ -89,46 +89,62 @@ CONTENT_TYPE_VISUALS: dict[str, str] = {
 }
 
 # Category keyword → visual cue (matched against category / tags / body).
+# Prefer institutions and front-page subjects — never generic lifestyle.
 CATEGORY_VISUAL_HINTS: tuple[tuple[tuple[str, ...], str], ...] = (
     (
+        (
+            'constitution', 'grundlag', 'قانون اساسی', 'riksdag', 'parliament',
+            'پارلمان', 'مجلس',
+        ),
+        'Riksdagen / Parliament building or official constitutional documents.',
+    ),
+    (
+        ('government', 'regering', 'دولت', 'politics', 'سیاست'),
+        'Government offices, official buildings, formal press setting.',
+    ),
+    (
         ('tax', 'skatt', 'مالیات', 'skatteverket'),
-        'Desk, tax papers, laptop, calculator, coffee — no readable text.',
+        'Tax authority office or desk with unmarked official documents.',
     ),
     (
         ('police', 'polis', 'پلیس'),
-        'Police officer, police vehicle, street or police station — no action.',
+        'Police officer, police vehicle, or police station — no action.',
     ),
     (
-        ('education', 'utbildning', 'آموزش', 'school', 'skolan'),
-        'Teacher, student, books, classroom.',
+        ('education', 'utbildning', 'آموزش', 'school', 'skolan', 'university'),
+        'School, university, classroom, students, teachers.',
     ),
     (
-        ('health', 'vård', 'سلامت', 'sjuk', 'healthcare', 'clinic'),
-        'Doctor, clinic, medical consultation — calm and respectful.',
+        ('health', 'vård', 'سلامت', 'sjuk', 'healthcare', 'clinic', 'hospital'),
+        'Hospital, doctor, medical equipment — calm and respectful.',
+    ),
+    (
+        ('economy', 'ekonomi', 'اقتصاد', 'finance', 'bank', 'industry'),
+        'Business district, finance office, industry — no readable charts.',
     ),
     (
         ('business', 'företag', 'کسب', 'company', 'office', 'entrepreneur'),
-        'Meeting, office, small company, entrepreneur.',
+        'Company office or professional workplace.',
     ),
     (
-        ('technology', 'teknik', 'فناوری', 'digital', 'developer'),
-        'Laptop, developer, modern office, clean workspace — no UI text.',
+        ('technology', 'teknik', 'فناوری', 'digital', 'developer', 'ai'),
+        'Servers, data centre, or clean tech workspace — no UI text.',
     ),
     (
         ('housing', 'bostad', 'مسکن', 'apartment', 'hyra'),
-        'Apartment, residential building, house keys, moving boxes.',
+        'Residential building exterior or apartment entrance.',
     ),
     (
         ('migration', 'مهاجرت', 'migrationsverket', 'asyl', 'uppehåll'),
-        'Government office, waiting area, documents, family — respectful.',
+        'Migration office, passport, border desk, official documents.',
     ),
     (
-        ('community', 'انجمن', 'community', 'volunteer'),
-        'Friendly conversation, helping each other, small group.',
+        ('culture', 'kultur', 'فرهنگ', 'museum', 'concert', 'artist'),
+        'Museum, concert hall, performance, or artist at work.',
     ),
     (
         ('transport', 'trafik', 'حمل', 'train', 'bus', 'bil', 'körkort'),
-        'Train, bus, road, or driving context — clear and uncluttered.',
+        'Train station, bus, or clear road context — uncluttered.',
     ),
 )
 

--- a/content_ai/editorial/persistence.py
+++ b/content_ai/editorial/persistence.py
@@ -6,9 +6,9 @@ AI must never publish. This layer only creates/updates Draft status Posts.
 from __future__ import annotations
 
 import logging
+import re
 
 from django.db import IntegrityError, transaction
-from django.utils import timezone
 from django.utils.text import slugify
 
 from blog.models import Category, Post
@@ -16,9 +16,29 @@ from content_ai.editorial.drafts import EditorialDraft
 
 logger = logging.getLogger(__name__)
 
+# Legacy collision stamps formerly appended by ``_unique_title``, e.g.
+# ``Title (20260726184315)`` or ``Title (20260726184315-2)``. Never re-add these.
+_LEGACY_TITLE_STAMP_RE = re.compile(r'\s*\((\d{14})(?:-\d+)?\)\s*$')
+
 
 class BlogDraftPersistenceError(Exception):
     """Raised when an EditorialDraft cannot be stored as a Blog draft."""
+
+
+def clean_blog_title(title: str) -> str:
+    """
+    Return the visible Blog title only.
+
+    Strips legacy workspace/timestamp collision suffixes. Never invents a new
+    prefix or suffix — uniqueness belongs on slug / post id / metadata.
+    """
+    cleaned = ' '.join((title or '').split()).strip()
+    while True:
+        nxt = _LEGACY_TITLE_STAMP_RE.sub('', cleaned).strip()
+        if nxt == cleaned:
+            break
+        cleaned = nxt
+    return cleaned[:200]
 
 
 class BlogDraftPersistenceService:
@@ -58,11 +78,25 @@ class BlogDraftPersistenceService:
         if category is None:
             raise BlogDraftPersistenceError('category is required.')
 
-        title = self._unique_title(
-            (editorial_draft.title or '').strip() or 'Untitled AI draft'
-        )
+        title = self._editorial_title(editorial_draft.title)
         content = self._compose_content(editorial_draft)
         excerpt = self._excerpt_for(editorial_draft)
+
+        # Prefer updating the author's existing draft with the same visible title
+        # instead of inventing a timestamped title for uniqueness.
+        existing = self._find_reusable_author_draft(title, author)
+        if existing is not None:
+            logger.info(
+                'create_blog_draft reusing existing draft pk=%s title=%r',
+                existing.pk,
+                title,
+            )
+            return self.update_blog_draft(
+                existing,
+                editorial_draft,
+                category=category,
+                source_url=source_url,
+            )
 
         logger.info(
             'create_blog_draft instantiating Post title=%r author=%s category=%s',
@@ -92,8 +126,20 @@ class BlogDraftPersistenceService:
                 )
         except IntegrityError as exc:
             logger.exception('create_blog_draft IntegrityError')
+            # Title is globally unique on Post. If another draft by this author
+            # won the race, reuse it. Never stamp the visible title.
+            raced = self._find_reusable_author_draft(title, author)
+            if raced is not None:
+                return self.update_blog_draft(
+                    raced,
+                    editorial_draft,
+                    category=category,
+                    source_url=source_url,
+                )
             raise BlogDraftPersistenceError(
-                f'Could not create Blog draft: {exc}'
+                'A Blog post with this exact title already exists. '
+                'Change the headline slightly, or open the existing draft '
+                'instead of creating a stamped title.'
             ) from exc
         except Exception:
             logger.exception('create_blog_draft unexpected error during post.save()')
@@ -129,10 +175,22 @@ class BlogDraftPersistenceService:
                 'Cannot update a deleted Blog draft.'
             )
 
-        title = self._unique_title(
-            (editorial_draft.title or '').strip() or post.title or 'Untitled AI draft',
-            exclude_pk=post.pk,
+        title = self._editorial_title(
+            editorial_draft.title or post.title or 'Untitled AI draft'
         )
+        # If the cleaned title belongs to another post, keep this post's current
+        # title only when it already matches; otherwise require a free title.
+        conflict = (
+            Post.objects.filter(title=title)
+            .exclude(pk=post.pk)
+            .first()
+        )
+        if conflict is not None:
+            raise BlogDraftPersistenceError(
+                'A Blog post with this exact title already exists. '
+                'Change the headline slightly — titles are never stamped with '
+                'workspace or timestamp identifiers.'
+            )
         post.title = title
         post.content = self._compose_content(editorial_draft)
         post.excerpt = self._excerpt_for(editorial_draft)
@@ -193,28 +251,53 @@ class BlogDraftPersistenceService:
         lead = (getattr(editorial_draft, 'lead', '') or '').strip()
         return lead[:500]
 
-    def _unique_title(self, base_title: str, *, exclude_pk=None) -> str:
-        """Ensure title uniqueness required by the Blog Post model."""
-        candidate = base_title[:200]
-        qs = Post.objects.all()
-        if exclude_pk is not None:
-            qs = qs.exclude(pk=exclude_pk)
-        if not qs.filter(title=candidate).exists():
-            return candidate
+    def _editorial_title(self, title: str) -> str:
+        """Visible Blog title only — no workspace/timestamp stamps."""
+        cleaned = clean_blog_title(title)
+        return cleaned or 'Untitled AI draft'
 
-        stamp = timezone.now().strftime('%Y%m%d%H%M%S')
-        suffix = f' ({stamp})'
-        max_base = 200 - len(suffix)
-        candidate = f'{base_title[:max_base]}{suffix}'
-        if not qs.filter(title=candidate).exists():
-            return candidate
+    def _find_reusable_author_draft(self, title: str, author):
+        """
+        Find this author's draft whose visible title matches ``title``.
 
-        for index in range(2, 50):
-            suffix = f' ({stamp}-{index})'
-            max_base = 200 - len(suffix)
-            candidate = f'{base_title[:max_base]}{suffix}'
-            if not qs.filter(title=candidate).exists():
-                return candidate
-        raise BlogDraftPersistenceError(
-            'Could not allocate a unique Blog draft title.'
+        Also matches legacy stamped titles like ``Title (20260726184315)``.
+        """
+        exact = (
+            Post.objects.filter(
+                title=title,
+                author=author,
+                status=self.DRAFT_STATUS,
+                is_deleted=False,
+            )
+            .order_by('-updated_on')
+            .first()
         )
+        if exact is not None:
+            return exact
+
+        prefix = title[:80]
+        if not prefix:
+            return None
+        candidates = (
+            Post.objects.filter(
+                author=author,
+                status=self.DRAFT_STATUS,
+                is_deleted=False,
+                title__startswith=prefix,
+            )
+            .order_by('-updated_on')[:25]
+        )
+        for post in candidates:
+            if clean_blog_title(post.title) == title:
+                return post
+        return None
+
+    def _unique_title(self, base_title: str, *, exclude_pk=None) -> str:
+        """
+        Compatibility wrapper.
+
+        Historically appended ``(YYYYMMDDHHMMSS)`` on collisions. That leaked into
+        Admin titles (especially under RTL). Uniqueness is handled by reusing
+        the author's draft or raising — never by mutating the visible title.
+        """
+        return self._editorial_title(base_title)

--- a/content_ai/editorial/persistence.py
+++ b/content_ai/editorial/persistence.py
@@ -16,8 +16,8 @@ from content_ai.editorial.drafts import EditorialDraft
 
 logger = logging.getLogger(__name__)
 
-# Legacy collision stamps formerly appended by ``_unique_title``, e.g.
-# ``Title (20260726184315)`` or ``Title (20260726184315-2)``. Never re-add these.
+# Legacy collision stamps formerly appended when Post.title was unique, e.g.
+# ``Title (20260726184315)``. Strip on write so editorial titles stay clean.
 _LEGACY_TITLE_STAMP_RE = re.compile(r'\s*\((\d{14})(?:-\d+)?\)\s*$')
 
 
@@ -27,10 +27,10 @@ class BlogDraftPersistenceError(Exception):
 
 def clean_blog_title(title: str) -> str:
     """
-    Return the visible Blog title only.
+    Return the visible Blog title exactly as editorial text.
 
-    Strips legacy workspace/timestamp collision suffixes. Never invents a new
-    prefix or suffix — uniqueness belongs on slug / post id / metadata.
+    Strips only legacy uniqueness stamps. Never invents a new prefix/suffix.
+    Uniqueness for URLs belongs on ``Post.slug``.
     """
     cleaned = ' '.join((title or '').split()).strip()
     while True:
@@ -64,7 +64,8 @@ class BlogDraftPersistenceService:
         """
         Create an unpublished Blog ``Post`` from ``editorial_draft``.
 
-        Slug generation is delegated to ``Post.save()``.
+        Slug generation / uniqueness is delegated to ``Post.save()``.
+        Titles are stored exactly (no uniqueness rewriting).
         """
         if not isinstance(editorial_draft, EditorialDraft):
             raise BlogDraftPersistenceError(
@@ -81,22 +82,6 @@ class BlogDraftPersistenceService:
         title = self._editorial_title(editorial_draft.title)
         content = self._compose_content(editorial_draft)
         excerpt = self._excerpt_for(editorial_draft)
-
-        # Prefer updating the author's existing draft with the same visible title
-        # instead of inventing a timestamped title for uniqueness.
-        existing = self._find_reusable_author_draft(title, author)
-        if existing is not None:
-            logger.info(
-                'create_blog_draft reusing existing draft pk=%s title=%r',
-                existing.pk,
-                title,
-            )
-            return self.update_blog_draft(
-                existing,
-                editorial_draft,
-                category=category,
-                source_url=source_url,
-            )
 
         logger.info(
             'create_blog_draft instantiating Post title=%r author=%s category=%s',
@@ -126,20 +111,8 @@ class BlogDraftPersistenceService:
                 )
         except IntegrityError as exc:
             logger.exception('create_blog_draft IntegrityError')
-            # Title is globally unique on Post. If another draft by this author
-            # won the race, reuse it. Never stamp the visible title.
-            raced = self._find_reusable_author_draft(title, author)
-            if raced is not None:
-                return self.update_blog_draft(
-                    raced,
-                    editorial_draft,
-                    category=category,
-                    source_url=source_url,
-                )
             raise BlogDraftPersistenceError(
-                'A Blog post with this exact title already exists. '
-                'Change the headline slightly, or open the existing draft '
-                'instead of creating a stamped title.'
+                f'Could not create Blog draft: {exc}'
             ) from exc
         except Exception:
             logger.exception('create_blog_draft unexpected error during post.save()')
@@ -175,23 +148,9 @@ class BlogDraftPersistenceService:
                 'Cannot update a deleted Blog draft.'
             )
 
-        title = self._editorial_title(
+        post.title = self._editorial_title(
             editorial_draft.title or post.title or 'Untitled AI draft'
         )
-        # If the cleaned title belongs to another post, keep this post's current
-        # title only when it already matches; otherwise require a free title.
-        conflict = (
-            Post.objects.filter(title=title)
-            .exclude(pk=post.pk)
-            .first()
-        )
-        if conflict is not None:
-            raise BlogDraftPersistenceError(
-                'A Blog post with this exact title already exists. '
-                'Change the headline slightly — titles are never stamped with '
-                'workspace or timestamp identifiers.'
-            )
-        post.title = title
         post.content = self._compose_content(editorial_draft)
         post.excerpt = self._excerpt_for(editorial_draft)
         post.status = self.DRAFT_STATUS
@@ -252,52 +211,16 @@ class BlogDraftPersistenceService:
         return lead[:500]
 
     def _editorial_title(self, title: str) -> str:
-        """Visible Blog title only — no workspace/timestamp stamps."""
+        """Preserve editorial title; strip legacy stamps only."""
         cleaned = clean_blog_title(title)
         return cleaned or 'Untitled AI draft'
-
-    def _find_reusable_author_draft(self, title: str, author):
-        """
-        Find this author's draft whose visible title matches ``title``.
-
-        Also matches legacy stamped titles like ``Title (20260726184315)``.
-        """
-        exact = (
-            Post.objects.filter(
-                title=title,
-                author=author,
-                status=self.DRAFT_STATUS,
-                is_deleted=False,
-            )
-            .order_by('-updated_on')
-            .first()
-        )
-        if exact is not None:
-            return exact
-
-        prefix = title[:80]
-        if not prefix:
-            return None
-        candidates = (
-            Post.objects.filter(
-                author=author,
-                status=self.DRAFT_STATUS,
-                is_deleted=False,
-                title__startswith=prefix,
-            )
-            .order_by('-updated_on')[:25]
-        )
-        for post in candidates:
-            if clean_blog_title(post.title) == title:
-                return post
-        return None
 
     def _unique_title(self, base_title: str, *, exclude_pk=None) -> str:
         """
         Compatibility wrapper.
 
-        Historically appended ``(YYYYMMDDHHMMSS)`` on collisions. That leaked into
-        Admin titles (especially under RTL). Uniqueness is handled by reusing
-        the author's draft or raising — never by mutating the visible title.
+        Historically appended ``(YYYYMMDDHHMMSS)`` when ``Post.title`` was unique.
+        Titles are no longer unique; this never mutates editorial text for
+        uniqueness. Slug uniqueness is handled by ``Post.save()``.
         """
         return self._editorial_title(base_title)

--- a/content_ai/tests/test_blog_integration.py
+++ b/content_ai/tests/test_blog_integration.py
@@ -92,7 +92,7 @@ class BlogDraftPersistenceServiceTests(TestCase):
         self.assertEqual(self.draft.language, 'sv')
         self.assertEqual(self.draft.metadata.get('provider'), 'mock')
 
-    def test_unique_title_collision_reuses_author_draft(self):
+    def test_duplicate_titles_allowed_slugs_stay_unique(self):
         existing = Post.objects.create(
             title='AI Housing Draft',
             slug='existing-ai-housing-draft',
@@ -106,10 +106,11 @@ class BlogDraftPersistenceServiceTests(TestCase):
             author=self.author,
             category=self.category,
         )
-        self.assertEqual(post.pk, existing.pk)
+        self.assertNotEqual(post.pk, existing.pk)
         self.assertEqual(post.title, 'AI Housing Draft')
-        self.assertNotIn('(', post.title)
-        self.assertEqual(post.status, 0)
+        self.assertEqual(existing.title, 'AI Housing Draft')
+        self.assertNotEqual(post.slug, existing.slug)
+        self.assertFalse(re.search(r'\(\d{14}', post.title))
 
     def test_save_draft_title_matches_workspace_exactly(self):
         persian = 'نگاهی جامع به قانون اساسی...'
@@ -127,38 +128,15 @@ class BlogDraftPersistenceServiceTests(TestCase):
         self.assertEqual(post.title, persian)
         self.assertFalse(re.search(r'\(\d{14}', post.title))
 
-        # Second Save Draft with the same workspace title must not stamp.
+        # Same title on a second draft is allowed; title stays exact.
         again = self.service.create_blog_draft(
             draft,
             author=self.author,
             category=self.category,
         )
-        self.assertEqual(again.pk, post.pk)
         self.assertEqual(again.title, persian)
-
-    def test_create_reuses_legacy_stamped_draft_and_cleans_title(self):
-        persian = 'نگاهی جامع به قانون اساسی...'
-        stamped = Post.objects.create(
-            title=f'{persian} (20260726184315)',
-            slug='legacy-stamped-reuse',
-            author=self.author,
-            category=self.category,
-            content='old',
-            status=0,
-        )
-        draft = EditorialDraft(
-            title=persian,
-            body='بدنه',
-            summary='خلاصه',
-            language='fa',
-        )
-        post = self.service.create_blog_draft(
-            draft,
-            author=self.author,
-            category=self.category,
-        )
-        self.assertEqual(post.pk, stamped.pk)
-        self.assertEqual(post.title, persian)
+        self.assertNotEqual(again.slug, post.slug)
+        self.assertEqual(Post.objects.filter(title=persian).count(), 2)
 
     def test_legacy_timestamp_suffix_stripped_on_update(self):
         stamped = Post.objects.create(

--- a/content_ai/tests/test_blog_integration.py
+++ b/content_ai/tests/test_blog_integration.py
@@ -1,3 +1,5 @@
+import re
+
 from django.contrib.auth import get_user_model
 from django.test import TestCase, override_settings
 
@@ -90,8 +92,8 @@ class BlogDraftPersistenceServiceTests(TestCase):
         self.assertEqual(self.draft.language, 'sv')
         self.assertEqual(self.draft.metadata.get('provider'), 'mock')
 
-    def test_unique_title_collision_gets_suffix(self):
-        Post.objects.create(
+    def test_unique_title_collision_reuses_author_draft(self):
+        existing = Post.objects.create(
             title='AI Housing Draft',
             slug='existing-ai-housing-draft',
             author=self.author,
@@ -104,9 +106,78 @@ class BlogDraftPersistenceServiceTests(TestCase):
             author=self.author,
             category=self.category,
         )
-        self.assertNotEqual(post.title, 'AI Housing Draft')
-        self.assertTrue(post.title.startswith('AI Housing Draft'))
+        self.assertEqual(post.pk, existing.pk)
+        self.assertEqual(post.title, 'AI Housing Draft')
+        self.assertNotIn('(', post.title)
         self.assertEqual(post.status, 0)
+
+    def test_save_draft_title_matches_workspace_exactly(self):
+        persian = 'نگاهی جامع به قانون اساسی...'
+        draft = EditorialDraft(
+            title=persian,
+            body='بدنه',
+            summary='خلاصه',
+            language='fa',
+        )
+        post = self.service.create_blog_draft(
+            draft,
+            author=self.author,
+            category=self.category,
+        )
+        self.assertEqual(post.title, persian)
+        self.assertFalse(re.search(r'\(\d{14}', post.title))
+
+        # Second Save Draft with the same workspace title must not stamp.
+        again = self.service.create_blog_draft(
+            draft,
+            author=self.author,
+            category=self.category,
+        )
+        self.assertEqual(again.pk, post.pk)
+        self.assertEqual(again.title, persian)
+
+    def test_create_reuses_legacy_stamped_draft_and_cleans_title(self):
+        persian = 'نگاهی جامع به قانون اساسی...'
+        stamped = Post.objects.create(
+            title=f'{persian} (20260726184315)',
+            slug='legacy-stamped-reuse',
+            author=self.author,
+            category=self.category,
+            content='old',
+            status=0,
+        )
+        draft = EditorialDraft(
+            title=persian,
+            body='بدنه',
+            summary='خلاصه',
+            language='fa',
+        )
+        post = self.service.create_blog_draft(
+            draft,
+            author=self.author,
+            category=self.category,
+        )
+        self.assertEqual(post.pk, stamped.pk)
+        self.assertEqual(post.title, persian)
+
+    def test_legacy_timestamp_suffix_stripped_on_update(self):
+        stamped = Post.objects.create(
+            title='نگاهی جامع به قانون اساسی... (20260726184315)',
+            slug='legacy-stamped-title',
+            author=self.author,
+            category=self.category,
+            content='old',
+            status=0,
+        )
+        draft = EditorialDraft(
+            title='نگاهی جامع به قانون اساسی...',
+            body='بدنه جدید',
+            summary='خلاصه',
+            language='fa',
+        )
+        result = self.service.update_blog_draft(stamped, draft)
+        self.assertEqual(result.title, 'نگاهی جامع به قانون اساسی...')
+        self.assertNotIn('20260726184315', result.title)
 
     def test_requires_author_and_category(self):
         with self.assertRaises(BlogDraftPersistenceError):

--- a/content_ai/tests/test_featured_image.py
+++ b/content_ai/tests/test_featured_image.py
@@ -6,6 +6,10 @@ from django.test import SimpleTestCase, TestCase, override_settings
 from django.contrib.auth import get_user_model
 from django.urls import reverse
 
+from content_ai.editorial.image.attach import (
+    extract_cloudinary_public_id,
+    resolve_featured_image_public_id,
+)
 from content_ai.editorial.image.planner import plan_featured_image
 from content_ai.editorial.image.prompt import build_featured_image_brief
 from content_ai.editorial.image.style import (
@@ -317,7 +321,15 @@ class FeaturedImageWorkspaceTests(SimpleTestCase):
             'save_blog_draft',
             return_value={'post_id': 42, 'title': 'عنوان', 'created': True},
         ), patch('blog.models.Post.objects.get') as mock_get:
-            mock_get.return_value = MagicMock(pk=42)
+            post = MagicMock(pk=42)
+            post.featured_image = MagicMock(public_id='peyvand/editorial/featured/test')
+            mock_get.return_value = post
+            # attach is mocked; simulate persisted public_id on refresh.
+            def _attach(p, *, public_id):
+                p.featured_image = MagicMock(public_id=public_id)
+                return p
+
+            mock_attach.side_effect = _attach
             result = service.accept_featured_image(session, user=user)
 
         self.assertTrue(result['accepted'])
@@ -326,9 +338,11 @@ class FeaturedImageWorkspaceTests(SimpleTestCase):
             result['cloudinary_public_id'],
             'peyvand/editorial/featured/test',
         )
-        # Preview upload on generate + final upload on Accept.
-        self.assertEqual(mock_upload.call_count, 2)
-        mock_attach.assert_called_once()
+        self.assertGreaterEqual(mock_attach.call_count, 1)
+        self.assertNotEqual(
+            session.metadata['featured_image'].get('cloudinary_public_id'),
+            '',
+        )
 
 
 @override_settings(
@@ -401,3 +415,91 @@ class FeaturedImageApiTests(TestCase):
             payload['session']['sections']['body'],
             'بدنه',
         )
+
+
+class CloudinaryPublicIdHelperTests(SimpleTestCase):
+    def test_extract_from_delivery_url(self):
+        url = (
+            'https://res.cloudinary.com/demo/image/upload/v1785091045/'
+            'peyvand/editorial/featured/abc123.png'
+        )
+        self.assertEqual(
+            extract_cloudinary_public_id(url),
+            'peyvand/editorial/featured/abc123',
+        )
+
+    def test_resolve_prefers_explicit_public_id(self):
+        pid = resolve_featured_image_public_id(
+            {
+                'cloudinary_public_id': 'peyvand/editorial/featured/x',
+                'image_url': 'https://res.cloudinary.com/demo/image/upload/v1/other.png',
+            }
+        )
+        self.assertEqual(pid, 'peyvand/editorial/featured/x')
+
+
+@override_settings(CONTENT_AI_PROVIDER='mock')
+class FeaturedImagePersistIntegrationTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        from blog.models import Category
+
+        self.user = User.objects.create_user(
+            username='imgpersist',
+            password='pass',
+            is_staff=True,
+        )
+        Category.objects.get_or_create(
+            slug='news',
+            defaults={'name': 'News'},
+        )
+
+    @patch('content_ai.workspace.services.upload_featured_image_asset')
+    def test_generate_accept_save_draft_sets_post_featured_image(self, mock_upload):
+        from blog.models import Post
+
+        public_id = 'peyvand/editorial/featured/integration-test'
+        secure_url = (
+            f'https://res.cloudinary.com/demo/image/upload/v1/{public_id}.png'
+        )
+        mock_upload.return_value = {
+            'public_id': public_id,
+            'secure_url': secure_url,
+        }
+
+        service = WorkspaceService()
+        session = service.new_session()
+        session.sections = ArticleSections(
+            headline='عنوان ادغام تصویر',
+            lead='لید خبر',
+            body='بدنه مقاله برای ذخیره پیش‌نویس.',
+            category='News',
+            tags=['test'],
+        )
+        service.prepare_featured_image_prompt(session)
+        generated = service.generate_featured_image(session)
+        self.assertEqual(generated['status'], 'generated')
+
+        accepted = service.accept_featured_image(session, user=self.user)
+        self.assertTrue(accepted['accepted'])
+        self.assertEqual(accepted['cloudinary_public_id'], public_id)
+
+        post_id = accepted['blog_draft']['post_id']
+        post = Post.objects.get(pk=post_id)
+        stored = (
+            getattr(post.featured_image, 'public_id', None)
+            or str(post.featured_image)
+        )
+        self.assertNotEqual(stored, 'placeholder')
+        self.assertEqual(stored, public_id)
+
+        # Save Draft again must keep the image (not reset to placeholder).
+        saved = service.save_blog_draft(session, user=self.user)
+        self.assertEqual(saved['post_id'], post_id)
+        post.refresh_from_db()
+        stored_after = (
+            getattr(post.featured_image, 'public_id', None)
+            or str(post.featured_image)
+        )
+        self.assertNotEqual(stored_after, 'placeholder')
+        self.assertEqual(stored_after, public_id)

--- a/content_ai/tests/test_featured_image.py
+++ b/content_ai/tests/test_featured_image.py
@@ -503,3 +503,73 @@ class FeaturedImagePersistIntegrationTests(TestCase):
         )
         self.assertNotEqual(stored_after, 'placeholder')
         self.assertEqual(stored_after, public_id)
+
+    @patch('content_ai.workspace.services.upload_featured_image_asset')
+    def test_save_draft_syncs_workspace_fields_to_blog_post(self, mock_upload):
+        """
+        Save Draft must copy workspace editorial fields onto the Blog draft.
+
+        Tags/SEO are stored on the draft payload (Blog Post has no tag/SEO
+        columns); Post fields must match workspace exactly.
+        """
+        from blog.models import Post
+
+        public_id = 'peyvand/editorial/featured/sync-checklist'
+        secure_url = (
+            f'https://res.cloudinary.com/demo/image/upload/v1/{public_id}.png'
+        )
+        mock_upload.return_value = {
+            'public_id': public_id,
+            'secure_url': secure_url,
+        }
+
+        headline = 'نگاهی جامع به قانون اساسی'
+        lead = 'لید خبر هم‌زمان'
+        body = 'متن اصلی مقاله بدون تغییر.'
+        summary = 'خلاصه دقیق برای excerpt'
+        tags = ['قانون اساسی', 'سوئد', 'حقوق']
+        source_url = 'https://example.se/source-article'
+
+        service = WorkspaceService()
+        session = service.new_session()
+        session.source_url = source_url
+        session.sections = ArticleSections(
+            headline=headline,
+            lead=lead,
+            body=body,
+            summary=summary,
+            category='News',
+            tags=tags,
+        )
+        service.seo_placeholders(session)
+        service.prepare_featured_image_prompt(session)
+        service.generate_featured_image(session)
+        service.accept_featured_image(session, user=self.user)
+
+        saved = service.save_blog_draft(session, user=self.user)
+        post = Post.objects.get(pk=saved['post_id'])
+
+        self.assertEqual(post.title, headline)
+        self.assertNotRegex(post.title, r'\(\d{14}')
+        self.assertNotIn(session.session_id, post.title)
+        self.assertEqual(post.excerpt, summary)
+        self.assertIn(lead, post.content)
+        self.assertIn(body, post.content)
+        self.assertEqual(post.category.name, 'News')
+        self.assertEqual(post.external_url, source_url)
+        self.assertEqual(saved['tags'], tags)
+        self.assertEqual(saved['seo']['keywords'], tags)
+        self.assertEqual(saved['seo']['seo_title'], headline[:60])
+        self.assertEqual(saved['source_url'], source_url)
+
+        stored = (
+            getattr(post.featured_image, 'public_id', None)
+            or str(post.featured_image)
+        )
+        self.assertNotEqual(stored, 'placeholder')
+        self.assertEqual(stored, public_id)
+        self.assertTrue(saved['featured_image']['accepted'])
+        self.assertEqual(
+            session.metadata['blog_sync']['title'],
+            headline,
+        )

--- a/content_ai/tests/test_featured_image.py
+++ b/content_ai/tests/test_featured_image.py
@@ -54,7 +54,10 @@ class FeaturedImagePromptTests(SimpleTestCase):
         self.assertIn('tax', brief.prompt.lower())
         self.assertTrue(brief.explanation)
         # Planner is internal — plan exists but UI must not show it.
-        self.assertIn('main_subject', brief.plan_dict())
+        plan_dict = brief.plan_dict()
+        self.assertIn('primary_visual_subject', plan_dict)
+        self.assertIn('main_subject', plan_dict)  # compatibility alias
+        self.assertIn('tax', plan_dict['primary_subject'].lower())
 
     def test_illustration_style(self):
         brief = build_featured_image_brief(
@@ -73,8 +76,65 @@ class FeaturedImagePromptTests(SimpleTestCase):
         self.assertEqual(resolve_image_style(None), DEFAULT_IMAGE_STYLE)
 
 
-class ImagePlannerTests(SimpleTestCase):
-    def test_planner_runs_before_prompt(self):
+class ImagePlannerV2Tests(SimpleTestCase):
+    def test_constitution_article_plans_parliament_not_lifestyle(self):
+        plan = plan_featured_image(
+            headline='بررسی قوانین اساسی و آیین‌نامه پارلمان سوئد',
+            lead=(
+                'قوانین اساسی و آیین‌نامه پارلمان سوئد نقش بنیادینی در نظام '
+                'حکمرانی این کشور ایفا می‌کنند.'
+            ),
+            body=(
+                'چهار ستون قانون اساسی سوئد شامل قانون حکومت، آزادی مطبوعات، '
+                'آزادی بیان و قانون جانشینی سلطنت است. ریکسداگ عالی‌ترین مظهر '
+                'اراده مردم است.'
+            ),
+            content_type='report',
+            category='سوئد امروز',
+            tags=['قانون اساسی', 'سوئد', 'ریکسداگ', 'دموکراسی'],
+        )
+        visual = plan.primary_visual_subject.lower()
+        self.assertIn('parliament', visual)
+        self.assertIn('riksdag', plan.location.lower())
+        self.assertNotIn('grocer', visual)
+        self.assertNotIn('elderly', visual)
+        self.assertNotIn('conversation', visual)
+        self.assertNotIn('helping', visual)
+        avoid_blob = ' '.join(plan.avoid).lower()
+        self.assertIn('lifestyle', avoid_blob)
+        self.assertIn('elderly', avoid_blob)
+        self.assertIn('shopping', avoid_blob)
+
+        brief = build_featured_image_brief(
+            headline='بررسی قوانین اساسی و آیین‌نامه پارلمان سوئد',
+            lead='قوانین اساسی و آیین‌نامه پارلمان سوئد نقش بنیادینی دارند.',
+            body='ریکسداگ و قانون اساسی سوئد.',
+            content_type='report',
+            category='سوئد امروز',
+            tags=['قانون اساسی', 'ریکسداگ'],
+            plan=plan,
+        )
+        prompt_l = brief.prompt.lower()
+        self.assertIn('primary visual subject', prompt_l)
+        self.assertIn('parliament', prompt_l)
+        self.assertIn('front-page', prompt_l)
+        self.assertNotIn('friendly conversation', prompt_l)
+        self.assertNotIn('helping each other', prompt_l)
+
+    def test_tax_article_plans_authority_not_coffee_lifestyle(self):
+        plan = plan_featured_image(
+            headline='افزایش مالیات برای مستاجران',
+            lead='سازمان مالیاتی قوانین جدیدی اعلام کرد.',
+            body='جزئیات قانون شامل مهلت و مبلغ است.',
+            content_type='news',
+            category='Tax',
+            tags=['skatt'],
+        )
+        self.assertIn('tax', plan.primary_subject.lower())
+        self.assertNotIn('coffee', plan.primary_visual_subject.lower())
+        self.assertTrue(plan.avoid)
+
+    def test_housing_article_plans_building(self):
         plan = plan_featured_image(
             headline='مسکن در استکهلم',
             lead='اجاره افزایش یافته است.',
@@ -83,9 +143,31 @@ class ImagePlannerTests(SimpleTestCase):
             category='Housing',
             tags=['bostad'],
         )
-        self.assertTrue(plan.main_subject)
-        self.assertIn('Low', plan.visual_complexity)
-        self.assertNotIn('fantasy', plan.main_subject.lower())
+        self.assertIn('residential', plan.primary_visual_subject.lower())
+        self.assertEqual(plan.primary_subject, 'Housing')
+        self.assertNotIn('fantasy', plan.primary_visual_subject.lower())
+
+    def test_planner_json_shape(self):
+        plan = plan_featured_image(
+            headline='پلیس استکهلم گزارش داد',
+            lead='نیروی پلیس عملیات آرامی انجام داد.',
+            body='جزئیات در ایستگاه پلیس اعلام شد.',
+            content_type='news',
+        )
+        data = plan.to_dict()
+        for key in (
+            'primary_subject',
+            'primary_visual_subject',
+            'location',
+            'secondary_elements',
+            'visual_style',
+            'mood',
+            'avoid',
+        ):
+            self.assertIn(key, data)
+        self.assertIsInstance(data['secondary_elements'], list)
+        self.assertIsInstance(data['avoid'], list)
+        self.assertLessEqual(len(data['secondary_elements']), 2)
 
 
 @override_settings(CONTENT_AI_PROVIDER='mock')

--- a/content_ai/tests/test_workspace.py
+++ b/content_ai/tests/test_workspace.py
@@ -581,6 +581,39 @@ class WorkspaceAPIIntegrationTests(TestCase):
         self.assertEqual(post.title, 'Workspace Save Draft Updated')
         self.assertIn('Updated body text', post.content)
 
+    def test_save_draft_blog_title_never_gets_workspace_timestamp_prefix(self):
+        from blog.models import Category, Post
+
+        Category.objects.create(name='News', slug='news')
+        headline = 'نگاهی جامع به قانون اساسی...'
+        # Seed a colliding draft so the old uniqueness path would have stamped.
+        Post.objects.create(
+            title=headline,
+            slug='existing-persian-headline',
+            author=self.staff,
+            category=Category.objects.get(slug='news'),
+            content='seed',
+            status=0,
+        )
+        response = self._post(
+            'save_draft',
+            {
+                'sections': {
+                    'headline': headline,
+                    'lead': 'مقدمه',
+                    'body': 'متن اصلی مقاله',
+                    'summary': 'خلاصه',
+                    'category': 'News',
+                },
+            },
+        )
+        self.assertEqual(response.status_code, 200, response.content.decode()[:500])
+        data = response.json()
+        self.assertTrue(data['ok'])
+        post = Post.objects.get(pk=data['blog_draft']['post_id'])
+        self.assertEqual(post.title, headline)
+        self.assertNotRegex(post.title, r'\(\d{14}')
+
     def test_publish_draft_then_reset_starts_clean_session(self):
         from blog.models import Category, Post
 

--- a/content_ai/workspace/services.py
+++ b/content_ai/workspace/services.py
@@ -1448,6 +1448,15 @@ class WorkspaceService:
                 ) from exc
 
         admin_url = reverse('admin:blog_post_change', args=[post.pk])
+        # Always refresh SEO snapshot from the current workspace sections so
+        # Save Draft stays synchronized (SEO is not a Blog Post column).
+        existing_seo = dict(session.metadata.get('seo') or {})
+        seo_state = {
+            **existing_seo,
+            'seo_title': (headline or post.title or '')[:60],
+            'meta_description': (post.excerpt or '')[:155],
+            'keywords': list(session.sections.tags),
+        }
         blog_draft = {
             'post_id': post.pk,
             'title': post.title,
@@ -1457,11 +1466,31 @@ class WorkspaceService:
             'category': post.category.name if post.category_id else '',
             'tags': list(session.sections.tags),
             'source_url': session.source_url or post.external_url or '',
+            'excerpt': post.excerpt or '',
+            'seo': {
+                'seo_title': seo_state.get('seo_title') or '',
+                'meta_description': seo_state.get('meta_description') or '',
+                'keywords': list(seo_state.get('keywords') or []),
+            },
             'featured_image': featured_meta,
         }
         session.metadata['linked_post_id'] = post.pk
         session.metadata['blog_draft'] = blog_draft
+        session.metadata['blog_sync'] = {
+            'title': post.title,
+            'excerpt': post.excerpt or '',
+            'category': blog_draft['category'],
+            'tags': list(session.sections.tags),
+            'external_url': post.external_url or '',
+            'seo': blog_draft['seo'],
+            'featured_image_public_id': featured_meta.get('cloudinary_public_id') or '',
+            'featured_image_accepted': bool(featured_meta.get('accepted')),
+        }
         session.metadata['featured_image_saved'] = featured_meta
+        session.metadata['seo'] = {
+            **seo_state,
+            **blog_draft['seo'],
+        }
         session.mark_pipeline('draft_generated', 'ready_for_publication')
         session.workflow_state = WorkflowState.READY_FOR_APPROVAL
         session.last_explanations = [

--- a/content_ai/workspace/services.py
+++ b/content_ai/workspace/services.py
@@ -32,6 +32,8 @@ from content_ai.editorial.image.style import (
 from content_ai.editorial.image.attach import (
     FeaturedImageAttachError,
     attach_featured_image_to_post,
+    extract_cloudinary_public_id,
+    resolve_featured_image_public_id,
     upload_featured_image_asset,
 )
 from content_ai.evaluation.evaluator import Evaluator
@@ -998,6 +1000,13 @@ class WorkspaceService:
                 )
                 state['image_url'] = upload.get('secure_url') or preview_url
                 state['preview_cloudinary_public_id'] = upload.get('public_id') or ''
+                # Persist public_id so Save Draft / Accept can attach without
+                # relying only on the accepted flag.
+                state['cloudinary_public_id'] = (
+                    upload.get('public_id')
+                    or state.get('cloudinary_public_id')
+                    or ''
+                )
                 logger.info(
                     'workspace image save (preview CDN): public_id=%s url=%s',
                     state.get('preview_cloudinary_public_id'),
@@ -1125,6 +1134,51 @@ class WorkspaceService:
         if current.get('status') == 'error':
             raise ValueError('Cannot accept a failed image — regenerate first.')
 
+        # Resolve / upload Cloudinary asset BEFORE save_blog_draft so the draft
+        # save path can attach using accepted + cloudinary_public_id.
+        existing_pid = resolve_featured_image_public_id(current)
+        if existing_pid and image_url.startswith('http'):
+            upload = {
+                'public_id': existing_pid,
+                'secure_url': (
+                    current.get('attached_url')
+                    or image_url
+                ),
+                'reused': True,
+            }
+            logger.info(
+                'accept_featured_image reusing Cloudinary public_id=%s',
+                existing_pid,
+            )
+        else:
+            upload = upload_featured_image_asset(
+                image_url,
+                public_id_prefix='peyvand/editorial/featured',
+                session_id=session.session_id or 'accept',
+            )
+
+        public_id = (upload.get('public_id') or '').strip()
+        secure_url = (upload.get('secure_url') or image_url).strip()
+        if not public_id:
+            raise FeaturedImageAttachError(
+                'Accept failed: Cloudinary public_id missing.'
+            )
+
+        state = dict(current)
+        state['accepted'] = True
+        state['pending_accept'] = False
+        state['status'] = 'accepted'
+        state['cloudinary_public_id'] = public_id
+        state['preview_cloudinary_public_id'] = (
+            current.get('preview_cloudinary_public_id') or public_id
+        )
+        state['attached_url'] = secure_url
+        state['image_url'] = secure_url
+        state['previous_image_url'] = current.get('previous_image_url') or ''
+        state['error'] = ''
+        session.metadata['featured_image'] = state
+
+        # save_blog_draft re-attaches when accepted + cloudinary_public_id set.
         blog_draft = self.save_blog_draft(session, user=user)
         post_id = blog_draft.get('post_id')
         if not post_id:
@@ -1133,26 +1187,26 @@ class WorkspaceService:
         from blog.models import Post
 
         post = Post.objects.get(pk=post_id)
-        upload = upload_featured_image_asset(
-            image_url,
-            session_id=session.session_id or str(post_id),
+        attach_featured_image_to_post(post, public_id=public_id)
+        post.refresh_from_db(fields=['featured_image'])
+        stored = (
+            getattr(post.featured_image, 'public_id', None)
+            or extract_cloudinary_public_id(str(post.featured_image))
+            or str(post.featured_image)
         )
-        attach_featured_image_to_post(post, public_id=upload['public_id'])
+        if not stored or stored == 'placeholder':
+            raise FeaturedImageAttachError(
+                f'Accept did not persist Post.featured_image '
+                f'(still {stored!r}).'
+            )
 
-        state = dict(current)
-        state['accepted'] = True
-        state['pending_accept'] = False
-        state['status'] = 'accepted'
-        state['cloudinary_public_id'] = upload['public_id']
-        state['attached_url'] = upload.get('secure_url') or image_url
-        state['previous_image_url'] = current.get('previous_image_url') or ''
-        state['error'] = ''
         state['attached_post_id'] = post.pk
         session.metadata['featured_image'] = state
         session.mark_pipeline('image_ready')
         session.last_explanations = [
             'Featured image accepted and attached to the Blog draft.',
-            f'Cloudinary: {upload["public_id"]}.',
+            f'Cloudinary: {public_id}.',
+            f'Post.featured_image={stored}.',
             'Article, SEO, tags, category and summary were not regenerated.',
         ]
         session.touch()
@@ -1261,6 +1315,7 @@ class WorkspaceService:
         session.sections.category = category.name
 
         featured = self._featured_image_state(session)
+        resolved_public_id = resolve_featured_image_public_id(featured)
         featured_meta = {
             'prompt': featured.get('prompt') or '',
             'original_prompt': featured.get('original_prompt') or '',
@@ -1268,11 +1323,18 @@ class WorkspaceService:
             'image_style_label': featured.get('image_style_label') or '',
             'aspect_ratio': featured.get('aspect_ratio') or '16:9',
             'status': featured.get('status') or '',
-            'cloudinary_public_id': featured.get('cloudinary_public_id') or '',
+            'cloudinary_public_id': (
+                featured.get('cloudinary_public_id')
+                or featured.get('preview_cloudinary_public_id')
+                or resolved_public_id
+                or ''
+            ),
             'accepted': bool(featured.get('accepted')),
             'image_url': featured.get('image_url') or '',
             'attached_url': featured.get('attached_url') or '',
         }
+        if resolved_public_id and not featured_meta['cloudinary_public_id']:
+            featured_meta['cloudinary_public_id'] = resolved_public_id
 
         draft = EditorialDraft(
             title=headline or 'Untitled AI draft',
@@ -1347,17 +1409,43 @@ class WorkspaceService:
                 raise ValueError(str(exc)) from exc
 
         # Keep an already-accepted featured image attached on Save Draft.
-        if featured_meta.get('accepted') and featured_meta.get('cloudinary_public_id'):
+        # Also recover when Accept set a Cloudinary URL but public_id was blank.
+        attach_pid = (
+            featured_meta.get('cloudinary_public_id')
+            or resolve_featured_image_public_id(featured_meta)
+            or ''
+        )
+        should_attach = bool(attach_pid) and (
+            featured_meta.get('accepted')
+            or featured_meta.get('status') == 'accepted'
+        )
+        if should_attach:
             try:
-                attach_featured_image_to_post(
-                    post,
-                    public_id=featured_meta['cloudinary_public_id'],
+                logger.info(
+                    'save_blog_draft attaching featured image post_id=%s '
+                    'public_id=%s',
+                    post.pk,
+                    attach_pid,
                 )
+                attach_featured_image_to_post(post, public_id=attach_pid)
+                post.refresh_from_db(fields=['featured_image'])
+                stored = (
+                    getattr(post.featured_image, 'public_id', None)
+                    or str(post.featured_image)
+                )
+                if not stored or stored == 'placeholder':
+                    raise FeaturedImageAttachError(
+                        f'Save Draft left featured_image as {stored!r}'
+                    )
+                featured_meta['cloudinary_public_id'] = attach_pid
+                featured_meta['accepted'] = True
             except FeaturedImageAttachError as exc:
-                logger.warning(
-                    'save_blog_draft could not re-attach featured image: %s',
-                    exc,
+                logger.exception(
+                    'save_blog_draft could not re-attach featured image'
                 )
+                raise ValueError(
+                    f'Could not attach featured image to Blog draft: {exc}'
+                ) from exc
 
         admin_url = reverse('admin:blog_post_change', args=[post.pk])
         blog_draft = {

--- a/docs/ai/features/APF-001B.md
+++ b/docs/ai/features/APF-001B.md
@@ -34,12 +34,30 @@ Never from URL alone. Never from title alone.
 
 ---
 
-## Image Planner (internal)
+## Image Planner v2 (internal)
 
-Determines main/secondary subject, environment, focus, camera, composition,
-mood, lighting, complexity, style, and things to avoid.
+Answers: *"If this article were on a newspaper front page, what should the
+photograph show?"* — not a generic Swedish lifestyle scene.
 
-**Not shown to editors** (stripped from API session payloads).
+Structured plan JSON (never shown to editors):
+
+```json
+{
+  "primary_subject": "...",
+  "primary_visual_subject": "...",
+  "location": "...",
+  "secondary_elements": [],
+  "visual_style": "...",
+  "mood": "...",
+  "avoid": []
+}
+```
+
+Category-specific institutional visuals (parliament, tax office, hospital,
+university, migration office, etc.). Explicit avoid list bans shopping,
+elderly lifestyle scenes, tourism, and similar unless the article is about them.
+
+The prompt generator builds the OpenAI prompt from this plan.
 
 ---
 


### PR DESCRIPTION
## Summary
- Save Draft now keeps the Blog title identical to the Workspace headline (no timestamp / workspace-id stamps).
- Accepted featured images attach to the Blog Post on Save Draft — `placeholder` is never kept after Accept.
- Workspace → Blog sync covers title, excerpt, content, category, tags, external URL, SEO snapshot, and featured image, with regression tests for the full checklist.

## Test plan
- [ ] Generate Article → Generate Image → Accept → Save Draft → confirm Blog `featured_image` ≠ `placeholder`
- [ ] Workspace title `نگاهی جامع به قانون اساسی` → Save Draft → Blog title exactly the same (no `(YYYYMMDDHHMMSS)` prefix/suffix)
- [ ] Confirm sync of title, excerpt, content, category, tags, external URL, SEO fields, and featured image
- [ ] Save Draft twice on the same session → deterministic update of the linked draft (no duplicate stamped titles)
- [ ] `DEBUG=True SECRET_KEY=test python3 manage.py test content_ai.tests.test_blog_integration content_ai.tests.test_featured_image.FeaturedImagePersistIntegrationTests content_ai.tests.test_workspace.WorkspaceAPIIntegrationTests.test_save_draft_blog_title_never_gets_workspace_timestamp_prefix`