### PR TITLE
Rotate latest discussions in homepage hero

### DIFF
--- a/blog/templates/blog/index.html
+++ b/blog/templates/blog/index.html
@@ -5,6 +5,7 @@
 {% block extra_css %}
 <link rel="stylesheet" href="{% static 'css/components/premium-cta-card.css' %}?v={% now 'U' %}" />
 <link rel="stylesheet" href="{% static 'css/components/homepage-pro-ads.css' %}?v={% now 'U' %}" />
+<link rel="stylesheet" href="{% static 'css/components/homepage-discussions-rotator.css' %}?v={% now 'U' %}" />
 {% endblock extra_css %}
 {% block content %}
 <!-- Mobile Hero Banner (< 768px only) -->
@@ -234,3 +235,7 @@
 
 <!-- index.html content ends here -->
 {% endblock %}
+
+{% block extras %}
+<script src="{% static 'js/homepage-discussions-rotator.js' %}" defer></script>
+{% endblock extras %}

--- a/blog/views.py
+++ b/blog/views.py
@@ -18,6 +18,7 @@ import json
 from .models import Post, Comment, Favorite, Category, Like
 from .forms import CommentForm, PostForm
 from related_links.selectors.related import get_related_links
+from community.selectors.discussions import list_latest_discussions
 from .utils import (
     track_page_view,
     determine_comment_approval,
@@ -98,6 +99,7 @@ class PostList(generic.ListView):
                 'featured_post': None,
                 'upcoming_events': [],
                 'homepage_pro_ads': [],
+                'latest_discussions': [],
             }
             return context
 
@@ -216,6 +218,11 @@ class PostList(generic.ListView):
             context['homepage_pro_ads'] = get_homepage_pro_ads()
         except Exception:
             context['homepage_pro_ads'] = []
+
+        try:
+            context['latest_discussions'] = list(list_latest_discussions()[:5])
+        except Exception:
+            context['latest_discussions'] = []
 
         try:
             expert_posts_qs = get_specialist_posts_queryset()

--- a/static/css/components/homepage-discussions-rotator.css
+++ b/static/css/components/homepage-discussions-rotator.css
@@ -1,0 +1,57 @@
+.hero-discussions-cta__body--rotator {
+  position: relative;
+  overflow: hidden;
+}
+
+.hero-discussions-rotator {
+  position: relative;
+  display: grid;
+  width: 100%;
+  min-width: 0;
+  place-items: center;
+}
+
+.hero-discussions-rotator__item {
+  grid-area: 1 / 1;
+  width: 100%;
+  margin: 0;
+  padding-inline: 0.15rem;
+  color: #4b5563;
+  font-size: clamp(0.74rem, 0.98vw, 0.94rem);
+  font-weight: 600;
+  line-height: 1.55;
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(0.5rem);
+  transition: opacity 220ms ease, transform 220ms ease, visibility 0s linear 220ms;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hero-discussions-rotator__item.is-active {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+  transition-delay: 0s;
+}
+
+@media (max-width: 767.98px) {
+  .hero-discussions-rotator__item {
+    font-size: clamp(0.68rem, 3.2vw, 0.78rem);
+    line-height: 1.45;
+  }
+}
+
+@media (min-width: 992px) {
+  .hero-discussions-rotator__item {
+    font-size: clamp(0.79rem, 0.91vw, 0.98rem);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .hero-discussions-rotator__item {
+    transform: none;
+    transition: none;
+  }
+}

--- a/static/js/homepage-discussions-rotator.js
+++ b/static/js/homepage-discussions-rotator.js
@@ -1,0 +1,49 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const rotators = document.querySelectorAll('[data-discussions-rotator]');
+  const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  rotators.forEach((rotator) => {
+    const titles = Array.from(rotator.querySelectorAll('[data-discussion-title]'));
+    if (titles.length < 2 || reduceMotion) return;
+
+    let currentIndex = 0;
+    let intervalId = null;
+
+    const showTitle = (nextIndex) => {
+      titles[currentIndex].classList.remove('is-active');
+      titles[currentIndex].setAttribute('aria-hidden', 'true');
+
+      currentIndex = nextIndex;
+      titles[currentIndex].classList.add('is-active');
+      titles[currentIndex].removeAttribute('aria-hidden');
+    };
+
+    const start = () => {
+      if (intervalId !== null) return;
+      intervalId = window.setInterval(() => {
+        showTitle((currentIndex + 1) % titles.length);
+      }, 3000);
+    };
+
+    const stop = () => {
+      if (intervalId === null) return;
+      window.clearInterval(intervalId);
+      intervalId = null;
+    };
+
+    const link = rotator.closest('.hero-discussions-cta');
+    if (link) {
+      link.addEventListener('mouseenter', stop);
+      link.addEventListener('mouseleave', start);
+      link.addEventListener('focusin', stop);
+      link.addEventListener('focusout', start);
+    }
+
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) stop();
+      else start();
+    });
+
+    start();
+  });
+});

--- a/templates/includes/hero_info_cards.html
+++ b/templates/includes/hero_info_cards.html
@@ -2,7 +2,7 @@
 <a
   href="{% url 'community:discussion_list' %}"
   class="hero-discussions-cta"
-  aria-label="گفتگوها — فضایی برای طرح موضوعات، تبادل تجربه و گفتگوهای سازنده"
+  aria-label="مشاهده صفحه گفتگوها"
 >
   <span class="hero-discussions-cta__accent">
     <span class="hero-discussions-cta__icon" aria-hidden="true">
@@ -10,9 +10,23 @@
     </span>
     <span class="hero-discussions-cta__title">گفتگوها</span>
   </span>
-  <span class="hero-discussions-cta__body">
-    <span class="hero-discussions-cta__description">
-      فضایی برای طرح موضوعات، تبادل تجربه و گفتگوهای سازنده
-    </span>
+  <span class="hero-discussions-cta__body hero-discussions-cta__body--rotator">
+    {% if latest_discussions %}
+      <span class="hero-discussions-rotator" data-discussions-rotator>
+        {% for discussion in latest_discussions %}
+          <span
+            class="hero-discussions-rotator__item{% if forloop.first %} is-active{% endif %}"
+            data-discussion-title
+            {% if not forloop.first %}aria-hidden="true"{% endif %}
+          >
+            {{ discussion.title }}
+          </span>
+        {% endfor %}
+      </span>
+    {% else %}
+      <span class="hero-discussions-cta__description">
+        فضایی برای طرح موضوعات، تبادل تجربه و گفتگوهای سازنده
+      </span>
+    {% endif %}
   </span>
 </a>


### PR DESCRIPTION
## What changed
- show the five latest public discussion titles in the homepage hero
- rotate titles every three seconds with a subtle fade/slide transition
- keep the full discussions card linked to the discussions index
- preserve the existing fallback copy when no discussions are available
- pause rotation on hover/focus and respect reduced-motion preferences

## Why
This replaces the static discussions description with current community activity, making the hero more useful without changing its overall layout.

## Validation
- `python -m py_compile blog/views.py`
- `node --check static/js/homepage-discussions-rotator.js`
- `git diff --check`

Full Django tests could not run in the temporary environment because dependency installation required unavailable system build support/cache access.