### PR TITLE
Refine homepage discussions rotator design

### DIFF
--- a/static/css/components/homepage-discussions-rotator.css
+++ b/static/css/components/homepage-discussions-rotator.css
@@ -1,6 +1,64 @@
 .hero-discussions-cta__body--rotator {
   position: relative;
   overflow: hidden;
+  flex-direction: column;
+  background:
+    radial-gradient(circle at 88% 12%, rgba(27, 85, 131, 0.09), transparent 38%),
+    linear-gradient(135deg, #ffffff 0%, #f8fbfd 100%);
+  border-inline-start: 1px solid rgba(27, 85, 131, 0.08);
+}
+
+.hero-discussions-cta__body--rotator::after {
+  position: absolute;
+  inset-inline-end: -2.5rem;
+  bottom: -3.5rem;
+  width: 7rem;
+  height: 7rem;
+  border: 1px solid rgba(27, 85, 131, 0.08);
+  border-radius: 50%;
+  content: "";
+  pointer-events: none;
+}
+
+.hero-discussions-rotator-shell,
+.hero-discussions-empty {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  justify-content: center;
+  width: 100%;
+  min-width: 0;
+  gap: 0.22rem;
+}
+
+.hero-discussions-rotator__eyebrow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  color: #1b5583;
+  font-size: clamp(0.58rem, 0.72vw, 0.68rem);
+  font-weight: 800;
+  line-height: 1.2;
+  letter-spacing: -0.01em;
+}
+
+.hero-discussions-rotator__eyebrow-mark {
+  width: 0.36rem;
+  height: 0.36rem;
+  flex: 0 0 auto;
+  border-radius: 50%;
+  background: #2d7aae;
+  box-shadow: 0 0 0 3px rgba(45, 122, 174, 0.12);
+}
+
+.hero-discussions-rotator__arrow {
+  margin-inline-start: 0.1rem;
+  font-size: 0.58rem;
+  opacity: 0.72;
+  transition: transform 180ms ease, opacity 180ms ease;
 }
 
 .hero-discussions-rotator {
@@ -16,15 +74,16 @@
   width: 100%;
   margin: 0;
   padding-inline: 0.15rem;
-  color: #4b5563;
-  font-size: clamp(0.74rem, 0.98vw, 0.94rem);
-  font-weight: 600;
-  line-height: 1.55;
+  color: #26394a;
+  font-size: clamp(0.76rem, 1vw, 0.96rem);
+  font-weight: 750;
+  line-height: 1.5;
   opacity: 0;
   visibility: hidden;
-  transform: translateY(0.5rem);
-  transition: opacity 220ms ease, transform 220ms ease, visibility 0s linear 220ms;
+  transform: translateY(0.45rem);
+  transition: opacity 260ms ease, transform 260ms ease, visibility 0s linear 260ms;
   overflow: hidden;
+  text-align: center;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -36,21 +95,91 @@
   transition-delay: 0s;
 }
 
+.hero-discussions-rotator__indicators {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 0.28rem;
+  gap: 0.25rem;
+}
+
+.hero-discussions-rotator__indicator {
+  width: 0.28rem;
+  height: 0.28rem;
+  border-radius: 999px;
+  background: rgba(27, 85, 131, 0.2);
+  transition: width 220ms ease, background-color 220ms ease;
+}
+
+.hero-discussions-rotator__indicator.is-active {
+  width: 0.82rem;
+  background: #2d7aae;
+}
+
+.hero-discussions-empty {
+  gap: 0.3rem;
+}
+
+.hero-discussions-empty .hero-discussions-cta__description {
+  color: #516273;
+  font-weight: 600;
+}
+
+@media (hover: hover) {
+  .hero-discussions-cta:hover .hero-discussions-rotator__arrow {
+    opacity: 1;
+    transform: translateX(-0.18rem);
+  }
+
+  .hero-discussions-cta:hover .hero-discussions-cta__body--rotator {
+    background:
+      radial-gradient(circle at 88% 12%, rgba(27, 85, 131, 0.13), transparent 40%),
+      linear-gradient(135deg, #ffffff 0%, #f4f9fc 100%);
+  }
+}
+
 @media (max-width: 767.98px) {
+  .hero-discussions-cta__body--rotator {
+    padding-block: 0.42rem;
+  }
+
+  .hero-discussions-rotator-shell {
+    gap: 0.18rem;
+  }
+
+  .hero-discussions-rotator__eyebrow {
+    font-size: 0.59rem;
+  }
+
   .hero-discussions-rotator__item {
-    font-size: clamp(0.68rem, 3.2vw, 0.78rem);
-    line-height: 1.45;
+    font-size: clamp(0.69rem, 3.2vw, 0.79rem);
+    line-height: 1.4;
+  }
+
+  .hero-discussions-rotator__indicator {
+    width: 0.24rem;
+    height: 0.24rem;
+  }
+
+  .hero-discussions-rotator__indicator.is-active {
+    width: 0.68rem;
   }
 }
 
 @media (min-width: 992px) {
+  .hero-discussions-rotator-shell {
+    gap: 0.28rem;
+  }
+
   .hero-discussions-rotator__item {
-    font-size: clamp(0.79rem, 0.91vw, 0.98rem);
+    font-size: clamp(0.8rem, 0.94vw, 1rem);
   }
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .hero-discussions-rotator__item {
+  .hero-discussions-rotator__item,
+  .hero-discussions-rotator__indicator,
+  .hero-discussions-rotator__arrow {
     transform: none;
     transition: none;
   }

--- a/static/js/homepage-discussions-rotator.js
+++ b/static/js/homepage-discussions-rotator.js
@@ -4,6 +4,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
   rotators.forEach((rotator) => {
     const titles = Array.from(rotator.querySelectorAll('[data-discussion-title]'));
+    const shell = rotator.closest('.hero-discussions-rotator-shell');
+    const indicators = shell
+      ? Array.from(shell.querySelectorAll('[data-discussion-indicator]'))
+      : [];
+
     if (titles.length < 2 || reduceMotion) return;
 
     let currentIndex = 0;
@@ -12,10 +17,12 @@ document.addEventListener('DOMContentLoaded', () => {
     const showTitle = (nextIndex) => {
       titles[currentIndex].classList.remove('is-active');
       titles[currentIndex].setAttribute('aria-hidden', 'true');
+      indicators[currentIndex]?.classList.remove('is-active');
 
       currentIndex = nextIndex;
       titles[currentIndex].classList.add('is-active');
       titles[currentIndex].removeAttribute('aria-hidden');
+      indicators[currentIndex]?.classList.add('is-active');
     };
 
     const start = () => {

--- a/templates/includes/hero_info_cards.html
+++ b/templates/includes/hero_info_cards.html
@@ -2,7 +2,7 @@
 <a
   href="{% url 'community:discussion_list' %}"
   class="hero-discussions-cta"
-  aria-label="مشاهده صفحه گفتگوها"
+  aria-label="مشاهده تازه‌ترین گفتگوها"
 >
   <span class="hero-discussions-cta__accent">
     <span class="hero-discussions-cta__icon" aria-hidden="true">
@@ -12,20 +12,41 @@
   </span>
   <span class="hero-discussions-cta__body hero-discussions-cta__body--rotator">
     {% if latest_discussions %}
-      <span class="hero-discussions-rotator" data-discussions-rotator>
-        {% for discussion in latest_discussions %}
-          <span
-            class="hero-discussions-rotator__item{% if forloop.first %} is-active{% endif %}"
-            data-discussion-title
-            {% if not forloop.first %}aria-hidden="true"{% endif %}
-          >
-            {{ discussion.title }}
-          </span>
-        {% endfor %}
+      <span class="hero-discussions-rotator-shell">
+        <span class="hero-discussions-rotator__eyebrow">
+          <span class="hero-discussions-rotator__eyebrow-mark" aria-hidden="true"></span>
+          <span>تازه‌ترین گفتگوها</span>
+          <i class="fas fa-arrow-left hero-discussions-rotator__arrow" aria-hidden="true"></i>
+        </span>
+        <span class="hero-discussions-rotator" data-discussions-rotator>
+          {% for discussion in latest_discussions %}
+            <span
+              class="hero-discussions-rotator__item{% if forloop.first %} is-active{% endif %}"
+              data-discussion-title
+              {% if not forloop.first %}aria-hidden="true"{% endif %}
+            >
+              {{ discussion.title }}
+            </span>
+          {% endfor %}
+        </span>
+        <span class="hero-discussions-rotator__indicators" aria-hidden="true">
+          {% for discussion in latest_discussions %}
+            <span
+              class="hero-discussions-rotator__indicator{% if forloop.first %} is-active{% endif %}"
+              data-discussion-indicator
+            ></span>
+          {% endfor %}
+        </span>
       </span>
     {% else %}
-      <span class="hero-discussions-cta__description">
-        فضایی برای طرح موضوعات، تبادل تجربه و گفتگوهای سازنده
+      <span class="hero-discussions-empty">
+        <span class="hero-discussions-rotator__eyebrow">
+          <span class="hero-discussions-rotator__eyebrow-mark" aria-hidden="true"></span>
+          <span>گفتگوها</span>
+        </span>
+        <span class="hero-discussions-cta__description">
+          فضایی برای طرح موضوعات، تبادل تجربه و گفتگوهای سازنده
+        </span>
       </span>
     {% endif %}
   </span>


### PR DESCRIPTION
## What changed
- add a compact «تازه‌ترین گفتگوها» label above the rotating title
- emphasize discussion titles with stronger typography and a refined blue-gray palette
- add animated slide indicators tied to the active discussion
- add a subtle directional arrow, layered background glow, and improved hover feedback
- preserve the existing three-second rotation, pause behavior, mobile layout, empty state, and reduced-motion support

## Impact
The discussions area now reads as a live, intentional part of the homepage hero while staying compact and consistent with Peyvand’s visual identity.

## Scope
Frontend-only refinement across the existing template, component stylesheet, and rotator script.