### PR TITLE
Emphasize the new discussion call to action

### DIFF
--- a/community/static/community/css/community.css
+++ b/community/static/community/css/community.css
@@ -138,20 +138,150 @@
   color: var(--community-ink-soft);
 }
 
-.community-home__create-link {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  font-size: 0.875rem;
-  font-weight: 600;
-  color: var(--community-accent);
-  text-decoration: none;
-  padding: 0.35rem 0;
-  transition: color 0.2s ease;
+.community-home__secondary-action {
+  width: 100%;
 }
 
-.community-home__create-link:hover {
-  color: var(--community-brand);
+.community-home__create-link {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+  min-height: 4.5rem;
+  gap: 0.85rem;
+  padding: 0.78rem 0.9rem;
+  border: 1px solid rgba(255, 255, 255, 0.14);
+  border-radius: 0.85rem;
+  color: #fff;
+  background:
+    radial-gradient(circle at 88% 18%, rgba(255, 255, 255, 0.15), transparent 34%),
+    linear-gradient(135deg, var(--community-accent) 0%, #123f63 100%);
+  box-shadow:
+    0 4px 10px rgba(11, 45, 74, 0.14),
+    0 12px 26px rgba(27, 85, 131, 0.16);
+  overflow: hidden;
+  text-decoration: none;
+  -webkit-tap-highlight-color: transparent;
+  transition:
+    transform 0.22s ease,
+    box-shadow 0.22s ease,
+    border-color 0.22s ease;
+}
+
+.community-home__create-link::after {
+  position: absolute;
+  inset-inline-end: -2.6rem;
+  bottom: -3.9rem;
+  width: 7.5rem;
+  height: 7.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.11);
+  border-radius: 50%;
+  content: "";
+  pointer-events: none;
+}
+
+.community-home__create-icon {
+  position: relative;
+  z-index: 1;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.45rem;
+  height: 2.45rem;
+  flex: 0 0 2.45rem;
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  border-radius: 50%;
+  background: rgba(255, 255, 255, 0.14);
+  color: #fff;
+  font-size: 0.88rem;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18);
+}
+
+.community-home__create-copy {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex: 1;
+  min-width: 0;
+  flex-direction: column;
+  gap: 0.16rem;
+}
+
+.community-home__create-copy strong {
+  font-size: 0.96rem;
+  font-weight: 800;
+  line-height: 1.35;
+}
+
+.community-home__create-copy small {
+  color: rgba(255, 255, 255, 0.78);
+  font-size: 0.72rem;
+  font-weight: 500;
+  line-height: 1.45;
+}
+
+.community-home__create-arrow {
+  position: relative;
+  z-index: 1;
+  flex: 0 0 auto;
+  margin-inline-start: 0.2rem;
+  color: rgba(255, 255, 255, 0.82);
+  font-size: 0.72rem;
+  transition: transform 0.2s ease, color 0.2s ease;
+}
+
+.community-home__create-link:focus-visible {
+  outline: 3px solid rgba(45, 122, 174, 0.3);
+  outline-offset: 3px;
+}
+
+@media (hover: hover) {
+  .community-home__create-link:hover {
+    color: #fff;
+    border-color: rgba(255, 255, 255, 0.25);
+    box-shadow:
+      0 7px 15px rgba(11, 45, 74, 0.18),
+      0 18px 36px rgba(27, 85, 131, 0.22);
+    transform: translateY(-2px);
+  }
+
+  .community-home__create-link:hover .community-home__create-arrow {
+    color: #fff;
+    transform: translateX(-0.22rem);
+  }
+}
+
+.community-home__create-link:active {
+  transform: translateY(0) scale(0.99);
+}
+
+@media (max-width: 767.98px) {
+  .community-home__create-link {
+    min-height: 4.25rem;
+    padding: 0.72rem 0.8rem;
+    border-radius: 0.75rem;
+  }
+
+  .community-home__create-icon {
+    width: 2.25rem;
+    height: 2.25rem;
+    flex-basis: 2.25rem;
+  }
+
+  .community-home__create-copy strong {
+    font-size: 0.92rem;
+  }
+
+  .community-home__create-copy small {
+    font-size: 0.68rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .community-home__create-link,
+  .community-home__create-arrow {
+    transition: none;
+  }
 }
 
 /* Stats — inline summary strip */

--- a/community/templates/community/includes/home_masthead.html
+++ b/community/templates/community/includes/home_masthead.html
@@ -35,8 +35,14 @@
 
         <div class="community-home__secondary-action">
           <a href="{{ create_discussion_url }}" class="community-home__create-link">
-            <i class="fas fa-plus" aria-hidden="true"></i>
-            ایجاد بحث جدید
+            <span class="community-home__create-icon" aria-hidden="true">
+              <i class="fas fa-plus"></i>
+            </span>
+            <span class="community-home__create-copy">
+              <strong>ایجاد بحث جدید</strong>
+              <small>پرسش، تجربه یا موضوعی را با دیگران در میان بگذارید</small>
+            </span>
+            <i class="fas fa-arrow-left community-home__create-arrow" aria-hidden="true"></i>
           </a>
         </div>
       </div>


### PR DESCRIPTION
## What changed
- replace the understated new-discussion text link with a full-width primary CTA
- add a circular plus icon, strong action label, and short supporting copy
- add a subtle directional arrow, branded gradient, depth, and hover/focus feedback
- make the CTA fully responsive and respect reduced-motion preferences

## Why
«ایجاد بحث جدید» is the primary contribution action on the discussions page, but its previous link treatment was easy to miss. This update gives it clear visual priority without adding a separate card or cluttering the masthead.

## Scope
Frontend-only: the existing URL and discussion creation flow are unchanged.