### PR TITLE
Style discussion topics as a sticky sidebar card

### DIFF
--- a/community/static/community/css/community.css
+++ b/community/static/community/css/community.css
@@ -427,6 +427,114 @@
   color: var(--community-ink-soft);
 }
 
+@media (min-width: 768px) {
+  .community-topic-nav {
+    position: sticky;
+    top: 6rem;
+    padding: 1rem;
+    border: 1px solid rgba(27, 85, 131, 0.12);
+    border-radius: 0.85rem;
+    background:
+      radial-gradient(circle at 90% 4%, rgba(27, 85, 131, 0.06), transparent 30%),
+      var(--community-surface);
+    box-shadow:
+      0 1px 2px rgba(15, 36, 56, 0.04),
+      0 8px 24px rgba(27, 85, 131, 0.07);
+  }
+
+  .community-topic-nav__heading {
+    margin: 0 0 0.7rem;
+    padding: 0 0.15rem 0.8rem;
+    border-bottom: 1px solid var(--community-line);
+    color: var(--community-brand);
+    font-size: 0.84rem;
+    font-weight: 800;
+    letter-spacing: 0;
+    text-transform: none;
+  }
+
+  .community-topic-nav__heading i {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.75rem;
+    height: 1.75rem;
+    border-radius: 0.45rem;
+    background: rgba(27, 85, 131, 0.09);
+    color: var(--community-accent);
+    font-size: 0.72rem;
+  }
+
+  .community-topic-grid {
+    gap: 0.22rem;
+  }
+
+  .community-topic {
+    position: relative;
+    min-height: 3.15rem;
+    padding: 0.52rem 0.58rem;
+    border-radius: 0.55rem;
+  }
+
+  .community-topic:hover {
+    background: rgba(27, 85, 131, 0.045);
+    border-color: rgba(27, 85, 131, 0.09);
+  }
+
+  .community-topic.is-active {
+    border-color: rgba(27, 85, 131, 0.14);
+    border-inline-start: 3px solid var(--community-accent);
+    background: linear-gradient(
+      90deg,
+      rgba(27, 85, 131, 0.035) 0%,
+      rgba(27, 85, 131, 0.09) 100%
+    );
+    box-shadow: 0 2px 7px rgba(27, 85, 131, 0.06);
+  }
+
+  .community-topic__icon {
+    width: 1.9rem;
+    height: 1.9rem;
+    border-radius: 0.42rem;
+  }
+
+  .community-topic__body {
+    flex: 1;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.4rem;
+  }
+
+  .community-topic__name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .community-topic__count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    flex: 0 0 auto;
+    min-width: 2.1rem;
+    padding: 0.13rem 0.38rem;
+    border: 1px solid rgba(27, 85, 131, 0.08);
+    border-radius: 999px;
+    background: rgba(27, 85, 131, 0.045);
+    color: #708595;
+    font-size: 0.65rem;
+    white-space: nowrap;
+  }
+
+  .community-topic.is-active .community-topic__count {
+    border-color: rgba(27, 85, 131, 0.13);
+    background: rgba(255, 255, 255, 0.72);
+    color: var(--community-brand);
+    font-weight: 700;
+  }
+}
+
 /* ── Discussion feed ──────────────────────────────────────── */
 
 .community-home__feed {


### PR DESCRIPTION
## What changed
- present the desktop/tablet topics navigation inside a restrained white sidebar card
- make the sidebar sticky below the site header
- add a clearer card heading, subtle border, shadow, and brand-tinted background detail
- emphasize the selected topic with an inline accent and stronger active state
- turn discussion counts into compact badges and improve row alignment
- preserve the existing horizontal chip-style navigation on mobile

## Why
The topics list already functions as the discussions sidebar, but lacked enough visual separation from the feed. This refinement makes the page hierarchy clearer without boxing each topic or adding visual weight on mobile.

## Scope
CSS-only visual refinement; category links, filtering, and template behavior are unchanged.