### PR TITLE
Fix homepage discussions card on mobile

### DIFF
--- a/static/css/components/homepage-discussions-rotator.css
+++ b/static/css/components/homepage-discussions-rotator.css
@@ -139,6 +139,19 @@
 }
 
 @media (max-width: 767.98px) {
+  main .hero-section--homepage .hero-section__info {
+    display: flex !important;
+    align-items: stretch;
+    justify-content: center;
+    visibility: visible;
+  }
+
+  main .hero-section--homepage .hero-discussions-cta {
+    display: flex !important;
+    visibility: visible;
+    opacity: 1;
+  }
+
   .hero-discussions-cta__body--rotator {
     padding-block: 0.42rem;
   }


### PR DESCRIPTION
## Summary
- explicitly render the homepage discussions container on screens below 768px
- keep the discussions card visible despite legacy mobile visibility/opacity rules
- preserve the existing five-title, 3-second rotation and discussions-page link

## Scope
CSS-only responsive fix in `homepage-discussions-rotator.css`.