### PR TITLE
Force mobile browsers to load the updated discussions rotator

### DIFF
--- a/blog/templates/blog/index.html
+++ b/blog/templates/blog/index.html
@@ -237,5 +237,5 @@
 {% endblock %}
 
 {% block extras %}
-<script src="{% static 'js/homepage-discussions-rotator.js' %}" defer></script>
+<script src="{% static 'js/homepage-discussions-rotator.js' %}?v={% now 'U' %}" defer></script>
 {% endblock extras %}


### PR DESCRIPTION
## علت
فایل JavaScript گردش گفتگوها بدون نسخه در URL لود می‌شد و مرورگر موبایل می‌توانست نسخه قدیمی را از cache اجرا کند. نسخه قدیمی در حالت Reduce Motion تایمر را متوقف می‌کرد.

## اصلاح
یک cache-busting version query به `homepage-discussions-rotator.js` اضافه شد تا پس از Deploy، موبایل حتماً فایل جدید را دریافت کند.

## نتیجه مورد انتظار
پنج عنوان گفتگو هر ۳ ثانیه در موبایل نیز تغییر می‌کنند.